### PR TITLE
Full-package review: correctness, Flyway interop, security, CI

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -15,7 +15,7 @@ jobs:
         run: which julia
         continue-on-error: true
       - name: Install Julia, but only if it is not already available in the PATH
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: '1'
           # arch: ${{ runner.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
           - os: windows-latest
             version: '1'
             arch: x86
+        exclude:
+          # Julia < 1.8 has no Apple Silicon binaries and macos-latest runners are ARM
+          - os: macOS-latest
+            version: '1.6'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -42,3 +46,21 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -29,24 +30,15 @@ jobs:
             version: '1'
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/previews-cleanup.yml
+++ b/.github/workflows/previews-cleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The Example.jl package is licensed under the MIT "Expat" License:
+The DBMigrations.jl package is licensed under the MIT "Expat" License:
 
 > Copyright (c) 2022: Jacob Quinn
 >

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
 CRC32 = "1"
-DBInterface = "2.5"
+DBInterface = "2.6"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DBMigrations"
 uuid = "277cf75d-8bce-46ef-b2a4-258a2479b121"
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 CRC32 = "b4567568-9dcc-467e-9b62-c342d3a501d3"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Migration files found in `dir` will be checked against a special `flyway_schema_
 the DBMigrations.jl package manages in the database connection for tracking which migrations have
 already been applied (the table name and layout are compatible with [Flyway](https://flywaydb.org/),
 including its line-ending-independent CRC32 checksums, so a history table previously managed by
-Flyway can be picked up by DBMigrations.jl). If a migration file is found in `dir` that has not been
+Flyway can be picked up by DBMigrations.jl). Flyway baseline rows also suppress all local versions
+at or below the baseline. If a migration file is found in `dir` that has not been
 applied, it will be applied to the database. If a migration file is found in `dir` that has already
 been applied, it will be skipped. If a migration file is found in `dir` that has been applied but
 has changed since it was applied, a `ChecksumMismatch` will be thrown (migrations should be

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Supported keyword arguments to `runmigrations`:
 Other error conditions: duplicate migration versions (in the directory or the history table) throw
 a `DuplicateMigrationError`; a migration recorded as failed in the history table (possible when
 sharing the table with Flyway) throws a `FailedMigrationError` and requires manual repair. Renaming
-an applied migration throws a `DescriptionMismatch`, consistent with Flyway validation.
+an applied migration throws a `DescriptionMismatch`. A history row with a different migration type
+throws a `TypeMismatch`. These checks are consistent with Flyway validation.
 
 `DBMigrations.clean!(conn; confirm=true)` drops and recreates the history table, forgetting all
 record of applied migrations (it does *not* undo the migrations themselves).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ immutable once applied).
 
 Migration files may contain multiple SQL statements, separated by semicolons. Each statement will
 be executed in order. Semicolons inside single-quoted strings, quoted identifiers, `--`/`/* */`
-comments, and Postgres dollar-quoted blocks are handled correctly. Each migration file is applied
+comments, and Postgres dollar-quoted blocks are handled correctly. Direct MySQL connections also
+use MySQL's `#` and whitespace-sensitive `--` comment rules. Each migration file is applied
 in a transaction: if any statement fails, the migration is rolled back and the error rethrown.
 
 Supported keyword arguments to `runmigrations`:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Supported keyword arguments to `runmigrations`:
     after `V3` was already applied); pass `true` to apply such migrations anyway
 
 Other error conditions: duplicate migration versions (in the directory or the history table) throw
-a `DuplicateMigrationError`; a migration recorded as failed in the history table (possible when
+a `DuplicateMigrationError`; duplicate history ranks throw a `DuplicateInstalledRankError`; a
+migration recorded as failed in the history table (possible when
 sharing the table with Flyway) throws a `FailedMigrationError` and requires manual repair. Renaming
 an applied migration throws a `DescriptionMismatch`. A history row with a different migration type
 throws a `TypeMismatch`. These checks are consistent with Flyway validation.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GitHub Actions : [![Build Status](https://github.com/JuliaServices/DBMigrations.
 DBMigrations.jl tries to be simple, transparent, and flexible. It relies on minimal required structure to work, while allowing for more complex setups.
 
 It aims to be compatible with all database packages that support the interfaces in [DBInterface.jl](https://github.com/JuliaDatabases/DBInterface.jl).
-Currently that includes SQLite.jl, MySQL.jl, LibPQ.jl, and ODBC.jl.
+Currently that includes SQLite.jl, MySQL.jl, Postgres.jl, LibPQ.jl, and ODBC.jl.
 
 The primary interface is calling `DBMigrations.runmigrations(conn::DBInterface.Connection, dir::String)`.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ record of applied migrations (it does *not* undo the migrations themselves).
     migration may leave earlier DDL statements applied).
   * Only versioned migrations are supported (no Flyway-style repeatable `R__` migrations or undo
     migrations).
+  * The statement splitter recognizes standard `''` quote escaping but not non-standard
+    backslash-escaped quotes (e.g. MySQL's default `\'`); use `''` doubling or
+    `splitstatements=false` for such files.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 ***A Julia package for managing database migrations***
 
-GitHub Actions : [![Build Status](https://github.com/JuliaServices/DBMigrations.jl/workflows/CI/badge.svg)](https://github.com/JuliaServices/DBMigrations.jl/actions?query=workflow%3ACI+branch%3Amaster)
+GitHub Actions : [![Build Status](https://github.com/JuliaServices/DBMigrations.jl/workflows/CI/badge.svg)](https://github.com/JuliaServices/DBMigrations.jl/actions?query=workflow%3ACI+branch%3Amain)
 
-[![codecov.io](http://codecov.io/github/JuliaServices/DBMigrations.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaServices/DBMigrations.jl?branch=master)
+[![codecov.io](http://codecov.io/github/JuliaServices/DBMigrations.jl/coverage.svg?branch=main)](http://codecov.io/github/JuliaServices/DBMigrations.jl?branch=main)
 
 ## Usage
 
 DBMigrations.jl tries to be simple, transparent, and flexible. It relies on minimal required structure to work, while allowing for more complex setups.
 
 It aims to be compatible with all database packages that support the interfaces in [DBInterface.jl](https://github.com/JuliaDatabases/DBInterface.jl).
-Currently that includes SQLite, MySQL, LibPQ.jl, and ODBC.jl.
+Currently that includes SQLite.jl, MySQL.jl, LibPQ.jl, and ODBC.jl.
 
 The primary interface is calling `DBMigrations.runmigrations(conn::DBInterface.Connection, dir::String)`.
 
@@ -24,17 +24,49 @@ a capital `V` followed by a number, followed by two underscores, followed by a d
 migration. The number must be unique across all migrations. The description can be anything, but
 should be descriptive of the migration. The file extension currently must be `.sql`.
 
-Migration files found in `dir` will be checked against a special `__migrations__` table that
+Migration files found in `dir` will be checked against a special `flyway_schema_history` table that
 the DBMigrations.jl package manages in the database connection for tracking which migrations have
-already been applied. If a migration file is found in `dir` that has not been applied, it will be
-applied to the database. If a migration file is found in `dir` that has already been applied, it
-will be skipped. If a migration file is found in `dir` that has been applied but has changed since
-it was applied, an error will be thrown (migrations should be immutable once applied).
+already been applied (the table name and layout are compatible with [Flyway](https://flywaydb.org/),
+including its line-ending-independent CRC32 checksums, so a history table previously managed by
+Flyway can be picked up by DBMigrations.jl). If a migration file is found in `dir` that has not been
+applied, it will be applied to the database. If a migration file is found in `dir` that has already
+been applied, it will be skipped. If a migration file is found in `dir` that has been applied but
+has changed since it was applied, a `ChecksumMismatch` will be thrown (migrations should be
+immutable once applied).
 
 Migration files may contain multiple SQL statements, separated by semicolons. Each statement will
-be executed in order. If any statement fails, the entire migration will be rolled back and an error
-will be thrown. If a migration file contains a syntax error, the migration will be rolled back and
-an error will be thrown.
+be executed in order. Semicolons inside single-quoted strings, quoted identifiers, `--`/`/* */`
+comments, and Postgres dollar-quoted blocks are handled correctly. Each migration file is applied
+in a transaction: if any statement fails, the migration is rolled back and the error rethrown.
+
+Supported keyword arguments to `runmigrations`:
+
+  * `silent::Bool=false`: suppress informational logging while applying migrations
+  * `splitstatements::Bool=true`: split each migration file on semicolons and execute each
+    statement separately; pass `false` to send each file's contents to the database driver as-is
+    (useful for constructs the splitter doesn't understand, like SQLite `CREATE TRIGGER` bodies
+    with embedded semicolons — note some drivers, e.g. SQLite, only execute the first statement
+    of a multi-statement string, so such constructs should live in their own file)
+  * `allowoutoforder::Bool=false`: by default an `OutOfOrderMigrationError` is thrown if a pending
+    migration has a version lower than the highest already-applied version (e.g. `V2` shows up
+    after `V3` was already applied); pass `true` to apply such migrations anyway
+
+Other error conditions: duplicate migration versions (in the directory or the history table) throw
+a `DuplicateMigrationError`; a migration recorded as failed in the history table (possible when
+sharing the table with Flyway) throws a `FailedMigrationError` and requires manual repair.
+
+`DBMigrations.clean!(conn; confirm=true)` drops and recreates the history table, forgetting all
+record of applied migrations (it does *not* undo the migrations themselves).
+
+## Limitations
+
+  * No locking is performed: if multiple processes run migrations against the same database
+    concurrently, they may race. Coordinate deployments externally.
+  * Transactional rollback of failed migrations depends on the database supporting transactional
+    DDL (SQLite and PostgreSQL do; MySQL auto-commits DDL statements, so a failed multi-statement
+    migration may leave earlier DDL statements applied).
+  * Only versioned migrations are supported (no Flyway-style repeatable `R__` migrations or undo
+    migrations).
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Supported keyword arguments to `runmigrations`:
 
 Other error conditions: duplicate migration versions (in the directory or the history table) throw
 a `DuplicateMigrationError`; a migration recorded as failed in the history table (possible when
-sharing the table with Flyway) throws a `FailedMigrationError` and requires manual repair.
+sharing the table with Flyway) throws a `FailedMigrationError` and requires manual repair. Renaming
+an applied migration throws a `DescriptionMismatch`, consistent with Flyway validation.
 
 `DBMigrations.clean!(conn; confirm=true)` drops and recreates the history table, forgetting all
 record of applied migrations (it does *not* undo the migrations themselves).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the DBMigrations.jl package manages in the database connection for tracking whic
 already been applied (the table name and layout are compatible with [Flyway](https://flywaydb.org/),
 including its line-ending-independent CRC32 checksums, so a history table previously managed by
 Flyway can be picked up by DBMigrations.jl). Flyway baseline rows also suppress all local versions
-at or below the baseline. If a migration file is found in `dir` that has not been
+at or below the baseline, and Flyway `DELETE` repair markers are honored. If a migration file is found in `dir` that has not been
 applied, it will be applied to the database. If a migration file is found in `dir` that has already
 been applied, it will be skipped. If a migration file is found in `dir` that has been applied but
 has changed since it was applied, a `ChecksumMismatch` will be thrown (migrations should be

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
+DBMigrations = "277cf75d-8bce-46ef-b2a4-258a2479b121"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,5 @@
-using Documenter, Example
+using Documenter, DBMigrations
 
-makedocs(modules = [Example], sitename = "Example.jl")
+makedocs(modules = [DBMigrations], sitename = "DBMigrations.jl")
 
-deploydocs(repo = "github.com/quinnj/Example.jl.git", push_preview = true)
+deploydocs(repo = "github.com/JuliaServices/DBMigrations.jl.git", push_preview = true)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,11 @@
-# Example
+# DBMigrations.jl
 
-Example Julia package repo.
+A Julia package for managing database migrations, compatible with any database package
+supporting the [DBInterface.jl](https://github.com/JuliaDatabases/DBInterface.jl) interfaces.
+The migration file format and schema history table are compatible with
+[Flyway](https://flywaydb.org/).
 
-```@autodocs
-Modules = [Example]
+```@docs
+DBMigrations.runmigrations
+DBMigrations.splitsqlstatements
 ```

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -168,10 +168,11 @@ function splitsqlstatements(sql::AbstractString)
             hascontent = true
             i = skipquoted(sql, n, i, c)
         elseif c == '-' && (k = nextind(sql, i); k <= n && sql[k] == '-')
-            i = something(findnext(==('\n'), sql, k), n + 1)
+            # a lone \r is a line ending too (consistent with the checksum algorithm)
+            i = something(findnext(x -> x == '\n' || x == '\r', sql, k), n + 1)
         elseif c == '/' && (k = nextind(sql, i); k <= n && sql[k] == '*')
             i = skipblockcomment(sql, n, i)
-        elseif c == '$' && (m = match(r"^\$[A-Za-z_][A-Za-z_0-9]*\$|^\$\$", SubString(sql, i)); m !== nothing)
+        elseif c == '$' && (m = match(r"^\$[\p{L}\p{M}_][\p{L}\p{M}\p{Nd}_]*\$|^\$\$", SubString(sql, i)); m !== nothing)
             hascontent = true
             closing = findnext(m.match, sql, i + ncodeunits(m.match))
             i = closing === nothing ? n + 1 : nextind(sql, last(closing))

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -213,7 +213,9 @@ function Migration(filename::String)
     return Migration(rank, version, description, "SQL", basename(filename), checksum, "DBMigrations.jl", "", 0, false, statements)
 end
 
-==(m1::Migration, m2::Migration) = m1.installed_rank == m2.installed_rank && m1.description == m2.description && m1.script == m2.script && isequal(m1.checksum, m2.checksum)
+==(m1::Migration, m2::Migration) = m1.installed_rank == m2.installed_rank && isequal(m1.version, m2.version) && m1.description == m2.description && m1.type == m2.type && m1.script == m2.script && isequal(m1.checksum, m2.checksum)
+
+Base.hash(m::Migration, h::UInt) = hash((m.installed_rank, m.version, m.description, m.type, m.script, m.checksum), h)
 
 struct DuplicateMigrationError <: Exception
     migrations::Vector{String}

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -68,7 +68,19 @@ function executewithcursor(f, conn, sql, params=nothing)
         end
     end
     actualparams = params === nothing ? () : params
-    return DBInterface.execute(f, conn, sql, actualparams)
+    statement = DBInterface.prepare(conn, sql)
+    try
+        cursor = DBInterface.execute(statement, actualparams)
+        try
+            return f(cursor)
+        finally
+            # ODBC.Cursor has no close! method. Closing its statement below releases
+            # the handle after the callback has consumed the rows.
+            closecursor(cursor)
+        end
+    finally
+        closecursor(statement)
+    end
 end
 
 function executecommand(conn, sql)

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -170,8 +170,13 @@ function splitsqlstatements(sql::AbstractString)
         elseif c == '-' && (k = nextind(sql, i); k <= n && sql[k] == '-')
             # a lone \r is a line ending too (consistent with the checksum algorithm)
             i = something(findnext(x -> x == '\n' || x == '\r', sql, k), n + 1)
+            # never emit a statement that *starts* with a comment: some drivers'
+            # tokenizers (e.g. SQLite's, which ends -- comments only at \n) could
+            # see the whole statement as a comment and fail on it
+            hascontent || (stmtstart = i)
         elseif c == '/' && (k = nextind(sql, i); k <= n && sql[k] == '*')
             i = skipblockcomment(sql, n, i)
+            hascontent || (stmtstart = i)
         elseif c == '$' && (m = match(r"^\$[\p{L}\p{M}_][\p{L}\p{M}\p{Nd}_]*\$|^\$\$", SubString(sql, i)); m !== nothing)
             hascontent = true
             closing = findnext(m.match, sql, i + ncodeunits(m.match))
@@ -206,8 +211,8 @@ Migration files found in `dir` will be checked against a special `$MIGRATIONS_TA
 the DBMigrations.jl package manages in the database connection for tracking which migrations have
 already been applied. History rows are matched to local files by version; the `installed_rank`
 column records application order (Flyway's semantics for the column, so a history table
-previously managed by Flyway can be picked up). If a migration file is found in `dir` that has not been
-applied to the database. If a migration file is found in `dir` that has already been applied, it
+previously managed by Flyway can be picked up). If a migration file is found in `dir` that has not
+been applied, it will be applied to the database. If a migration file is found in `dir` that has already been applied, it
 will be skipped. If a migration file is found in `dir` that has been applied but has changed since
 it was applied, an error will be thrown (migrations should be immutable once applied).
 

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -55,7 +55,7 @@ end
 
 Migration(rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success) = Migration(rank, version, description, type, script, coalesce(checksum, 0), installed_by, installed_on, execution_time, success, "")
 
-const MIGRATION_FILE_REGEX = r"^V(\d+)__(\w+)\.sql$"
+const MIGRATION_FILE_REGEX = r"^V(\d+)__(.+)\.sql$"
 
 # filename matches MIGRATION_FILE_REGEX
 function Migration(filename::String)
@@ -239,7 +239,14 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             rethrow()
         end
     end
-    files = filter!(x -> match(MIGRATION_FILE_REGEX, basename(x)) !== nothing, readdir(dir; join=true))
+    allfiles = readdir(dir; join=true)
+    files = filter(x -> match(MIGRATION_FILE_REGEX, basename(x)) !== nothing, allfiles)
+    if !silent
+        # .sql files that don't match the migration naming pattern are easy to mistake
+        # for migrations, so call them out instead of silently ignoring them
+        skipped = [basename(x) for x in allfiles if endswith(x, ".sql") && match(MIGRATION_FILE_REGEX, basename(x)) === nothing]
+        isempty(skipped) || @warn "Ignoring .sql files that don't match the `V<version>__<description>.sql` migration naming pattern: $skipped"
+    end
     migrations = sort!(map(Migration, files), by=x->x.installed_rank)
     # check that all local migration versions are unique before comparing against the db
     if !allunique(m.installed_rank for m in migrations)

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -412,13 +412,24 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
         haskey(dbbyversion, k) && throw(DuplicateMigrationError([x.script for x in dbmigrations if x.version !== missing && versionkey(x.version) == k]))
         dbbyversion[k] = dbm
     end
+    # A Flyway baseline declares every lower version already represented by the
+    # database state even though those versions have no individual history rows.
+    baselineversions = Int[]
+    for dbm in dbmigrations
+        dbm.version === missing && continue
+        uppercase(dbm.type) == "BASELINE" || continue
+        p = tryparse(Int, dbm.version)
+        p === nothing || push!(baselineversions, p)
+    end
+    baselineversion = isempty(baselineversions) ? nothing : maximum(baselineversions)
     # filter out migrations that have already been applied
     migrations_to_run = Migration[]
     for m in migrations
         dbm = get(dbbyversion, versionkey(m.version), nothing)
         if dbm === nothing
-            # not applied yet, so it needs to be run
-            push!(migrations_to_run, m)
+            # Versions at or below a Flyway baseline are represented by that baseline
+            # row and must not be run against the existing database state.
+            (baselineversion === nothing || m.installed_rank > baselineversion) && push!(migrations_to_run, m)
         elseif dbm.checksum !== missing && dbm.description != m.description && dbm.description != legacydescription(m)
             throw(DescriptionMismatch(m.script, m.description, dbm.description))
         elseif dbm.checksum !== missing && dbm.checksum != m.checksum

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -99,6 +99,83 @@ end
 
 Base.showerror(io::IO, e::FailedMigrationError) = print(io, "Migration $(e.script) previously failed (success=false in $MIGRATIONS_TABLE). Manually repair the database and remove the failed row before re-running migrations")
 
+# skip a quoted region starting at `i` (opening quote char `q`), where a doubled
+# quote is an escape; returns the index just past the closing quote
+function skipquoted(sql, n, i, q)
+    j = nextind(sql, i)
+    while j <= n
+        if sql[j] == q
+            k = nextind(sql, j)
+            (k <= n && sql[k] == q) || return k
+            j = nextind(sql, k)
+        else
+            j = nextind(sql, j)
+        end
+    end
+    return j
+end
+
+# skip a `/* */` block comment starting at `i`, honoring nesting (Postgres);
+# returns the index just past the closing `*/`
+function skipblockcomment(sql, n, i)
+    j = nextind(sql, nextind(sql, i))
+    depth = 1
+    while j <= n && depth > 0
+        c = sql[j]
+        k = nextind(sql, j)
+        if c == '*' && k <= n && sql[k] == '/'
+            depth -= 1
+            j = nextind(sql, k)
+        elseif c == '/' && k <= n && sql[k] == '*'
+            depth += 1
+            j = nextind(sql, k)
+        else
+            j = k
+        end
+    end
+    return j
+end
+
+"""
+    DBMigrations.splitsqlstatements(sql::AbstractString)
+
+Split `sql` into individual statements on semicolons, ignoring semicolons that appear
+inside single-quoted strings, double-quoted or backtick-quoted identifiers, line (`--`)
+and block (`/* */`, nesting allowed) comments, and Postgres dollar-quoted (`\$tag\$`)
+blocks. Chunks containing only whitespace/comments are dropped.
+"""
+function splitsqlstatements(sql::AbstractString)
+    statements = String[]
+    n = lastindex(sql)
+    stmtstart = firstindex(sql)
+    hascontent = false
+    i = firstindex(sql)
+    while i <= n
+        c = sql[i]
+        if c == ';'
+            hascontent && push!(statements, strip(SubString(sql, stmtstart, prevind(sql, i))))
+            stmtstart = i = nextind(sql, i)
+            hascontent = false
+        elseif c == '\'' || c == '"' || c == '`'
+            hascontent = true
+            i = skipquoted(sql, n, i, c)
+        elseif c == '-' && (k = nextind(sql, i); k <= n && sql[k] == '-')
+            i = something(findnext(==('\n'), sql, k), n + 1)
+        elseif c == '/' && (k = nextind(sql, i); k <= n && sql[k] == '*')
+            i = skipblockcomment(sql, n, i)
+        elseif c == '$' && (m = match(r"^\$[A-Za-z_][A-Za-z_0-9]*\$|^\$\$", SubString(sql, i)); m !== nothing)
+            hascontent = true
+            closing = findnext(m.match, sql, i + ncodeunits(m.match))
+            i = closing === nothing ? n + 1 : nextind(sql, last(closing))
+        else
+            hascontent |= !isspace(c)
+            i = nextind(sql, i)
+        end
+    end
+    hascontent && push!(statements, strip(SubString(sql, stmtstart, n)))
+    return statements
+end
+
 function getmigrations(conn)
     # select columns explicitly: the Migration constructor is positional, so we can't
     # depend on the physical column order of a pre-existing (e.g. Flyway-created) table
@@ -126,13 +203,16 @@ it was applied, an error will be thrown (migrations should be immutable once app
 Migration files may contain multiple SQL statements, separated by semicolons. Each statement will
 be executed in order. If any statement fails, the entire migration will be rolled back and an error
 will be thrown. If a migration file contains a syntax error, the migration will be rolled back and
-an error will be thrown.
+an error will be thrown. Semicolons inside single-quoted strings, quoted identifiers, `--` and
+`/* */` comments, and Postgres dollar-quoted blocks are not treated as statement separators.
 
 Supported keyword arguments:
   * `silent::Bool=false`: suppress informational logging while applying migrations
   * `splitstatements::Bool=true`: split each migration file on semicolons and execute each
     statement separately; pass `false` to pass each file's contents to the database driver
-    as-is (note some drivers, e.g. SQLite, only execute the first statement of a multi-statement string)
+    as-is, e.g. for constructs the splitter doesn't understand such as SQLite `CREATE TRIGGER`
+    bodies with embedded semicolons (note some drivers, e.g. SQLite, only execute the first
+    statement of a multi-statement string, so such constructs should live in their own file)
   * `allowoutoforder::Bool=false`: by default, an `OutOfOrderMigrationError` is thrown if a
     pending migration has a version lower than the highest already-applied version (e.g. `V2`
     shows up after `V3` was already applied); pass `true` to apply such migrations anyway
@@ -202,12 +282,9 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             start = time()
             silent || @info "Applying migrations from file: $(m.script)"
             if splitstatements
-                for statement in split(m.statements, ';')
-                    statement = strip(statement)
-                    if !isempty(statement)
-                        silent || @info "Applying migration statement:\n$statement"
-                        DBInterface.execute(conn, statement)
-                    end
+                for statement in splitsqlstatements(m.statements)
+                    silent || @info "Applying migration statement:\n$statement"
+                    DBInterface.execute(conn, statement)
                 end
             else
                 silent || @info "Applying migration statement:\n$(m.statements)"

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -319,7 +319,7 @@ end
 
 # skip a `/* */` block comment starting at `i`, honoring nesting (Postgres);
 # returns the index just past the closing `*/`
-function skipblockcomment(sql, n, i)
+function skipblockcomment(sql, n, i, nestedcomments)
     j = nextind(sql, nextind(sql, i))
     depth = 1
     while j <= n && depth > 0
@@ -328,7 +328,7 @@ function skipblockcomment(sql, n, i)
         if c == '*' && k <= n && sql[k] == '/'
             depth -= 1
             j = nextind(sql, k)
-        elseif c == '/' && k <= n && sql[k] == '*'
+        elseif nestedcomments && c == '/' && k <= n && sql[k] == '*'
             depth += 1
             j = nextind(sql, k)
         else
@@ -360,7 +360,9 @@ backslash-escaped quotes (e.g. MySQL's default `\\'`) are not recognized — use
 """
 splitsqlstatements(sql::AbstractString) = splitsqlstatements(sql, false)
 
-function splitsqlstatements(sql::AbstractString, mysqlcomments::Bool)
+splitsqlstatements(sql::AbstractString, mysqlcomments::Bool) = splitsqlstatements(sql, mysqlcomments, !mysqlcomments)
+
+function splitsqlstatements(sql::AbstractString, mysqlcomments::Bool, nestedcomments::Bool)
     statements = String[]
     n = lastindex(sql)
     stmtstart = firstindex(sql)
@@ -398,7 +400,7 @@ function splitsqlstatements(sql::AbstractString, mysqlcomments::Bool)
             marker = after <= n ? sql[after] : '\0'
             executable = marker == '!'
             hint = marker == '+'
-            i = skipblockcomment(sql, n, i)
+            i = skipblockcomment(sql, n, i, nestedcomments)
             executable && (hascontent = true)
             !hascontent && !hint && (stmtstart = i)
         elseif c == '$' && candollarquote(sql, i) && (m = match(r"^\$[\p{L}\p{M}_][\p{L}\p{M}\p{Nd}_]*\$|^\$\$", SubString(sql, i)); m !== nothing)
@@ -571,7 +573,9 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             start = time()
             silent || @info "Applying migrations from file: $(m.script)"
             if splitstatements
-                for statement in splitsqlstatements(m.statements, ismysqlconnection(conn))
+                mysqlcomments = ismysqlconnection(conn)
+                nestedcomments = !mysqlcomments && !issqliteconnection(conn)
+                for statement in splitsqlstatements(m.statements, mysqlcomments, nestedcomments)
                     executecommand(conn, statement)
                 end
             else

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -17,7 +17,8 @@ CREATE TABLE $MIGRATIONS_TABLE (
     installed_by VARCHAR(100) NOT NULL,
     installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     execution_time INTEGER NOT NULL,
-    success BOOLEAN NOT NULL
+    success BOOLEAN NOT NULL,
+    CONSTRAINT $(MIGRATIONS_TABLE)_pk PRIMARY KEY (installed_rank)
 );
 """
 

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -22,12 +22,70 @@ CREATE TABLE $MIGRATIONS_TABLE (
 );
 """
 
-# render a value as a SQL literal, escaping embedded single quotes
-sqlliteral(s::AbstractString) = string('\'', replace(s, '\'' => "''"), '\'')
-sqlliteral(::Missing) = "NULL"
+# These packages cannot be hard dependencies, so identify the one driver whose
+# DBInterface placeholder and transaction behavior differs from the other supported
+# drivers. LibPQ.DBConnection is the public DBInterface connection wrapper.
+function islibpqconnection(conn)
+    T = typeof(conn)
+    return nameof(T) === :DBConnection && nameof(parentmodule(T)) === :LibPQ
+end
+
+function closelibpqresult(conn, sql, params=nothing)
+    result = params === nothing ? DBInterface.execute(conn, sql) : DBInterface.execute(conn, sql, params)
+    try
+        return nothing
+    finally
+        close(result)
+    end
+end
+
+function executebound(conn, sql, params)
+    if islibpqconnection(conn)
+        # LibPQ uses $1 placeholders and its Statement is not a DBInterface.Statement,
+        # so use its direct parameter execution path and close the Result explicitly.
+        closelibpqresult(conn, sql, params)
+    else
+        # SQLite, MySQL, and ODBC use `?`. The callback form closes both the cursor
+        # and the one-shot prepared statement on all three drivers.
+        DBInterface.execute(conn, sql, params) do _
+            nothing
+        end
+    end
+end
 
 function insertmigration!(conn, m, rank, etime)
-    DBInterface.execute(conn, "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($rank, $(sqlliteral(m.version)), $(sqlliteral(m.description)), $(sqlliteral(m.type)), $(sqlliteral(m.script)), $(m.checksum), $(sqlliteral(m.installed_by)), $(max(0, etime)), true)")
+    markers = islibpqconnection(conn) ? join(("\$$i" for i = 1:9), ", ") : join(fill("?", 9), ", ")
+    sql = "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($markers)"
+    # MySQL.jl does not bind Bool correctly on all supported releases. Int8(1)
+    # round-trips as true through SQLite/MySQL/Postgres/ODBC boolean columns.
+    params = (rank, m.version, m.description, m.type, m.script, m.checksum, m.installed_by, max(0, etime), Int8(1))
+    executebound(conn, sql, params)
+end
+
+function migrationtransaction(f, conn)
+    islibpqconnection(conn) || return DBInterface.transaction(f, conn)
+
+    # DBInterface 2.7 prepares transaction-control statements. LibPQ.Statement does
+    # not implement DBInterface.Statement/close!, so that generic path fails before
+    # BEGIN. Direct execution also works on DBInterface 2.6, the Julia 1.6 minimum.
+    closelibpqresult(conn, "BEGIN;")
+    try
+        result = f()
+        closelibpqresult(conn, "COMMIT;")
+        return result
+    catch transaction_error
+        transaction_backtrace = catch_backtrace()
+        try
+            closelibpqresult(conn, "ROLLBACK;")
+        catch rollback_error
+            rollback_backtrace = catch_backtrace()
+            throw(CompositeException([
+                CapturedException(transaction_error, transaction_backtrace),
+                CapturedException(rollback_error, rollback_backtrace),
+            ]))
+        end
+        rethrow()
+    end
 end
 
 struct ChecksumMismatch <: Exception
@@ -336,7 +394,7 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     # onwards), matching Flyway's semantics for the column
     nextrank = (isempty(dbmigrations) ? 0 : maximum(dbm.installed_rank for dbm in dbmigrations)) + 1
     for m in migrations_to_run
-        DBInterface.transaction(conn) do
+        migrationtransaction(conn) do
             start = time()
             silent || @info "Applying migrations from file: $(m.script)"
             if splitstatements

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -26,8 +26,8 @@ CREATE TABLE $MIGRATIONS_TABLE (
 sqlliteral(s::AbstractString) = string('\'', replace(s, '\'' => "''"), '\'')
 sqlliteral(::Missing) = "NULL"
 
-function insertmigration!(conn, m, etime)
-    DBInterface.execute(conn, "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($(m.installed_rank), $(sqlliteral(m.version)), $(sqlliteral(m.description)), $(sqlliteral(m.type)), $(sqlliteral(m.script)), $(m.checksum), $(sqlliteral(m.installed_by)), $(max(0, etime)), true)")
+function insertmigration!(conn, m, rank, etime)
+    DBInterface.execute(conn, "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($rank, $(sqlliteral(m.version)), $(sqlliteral(m.description)), $(sqlliteral(m.type)), $(sqlliteral(m.script)), $(m.checksum), $(sqlliteral(m.installed_by)), $(max(0, etime)), true)")
 end
 
 struct ChecksumMismatch <: Exception
@@ -99,6 +99,9 @@ struct FailedMigrationError <: Exception
 end
 
 Base.showerror(io::IO, e::FailedMigrationError) = print(io, "Migration $(e.script) previously failed (success=false in $MIGRATIONS_TABLE). Manually repair the database and remove the failed row before re-running migrations")
+
+# normalize integer-like version strings so e.g. '05' and '5' compare equal
+versionkey(v::AbstractString) = (p = tryparse(Int, v); p === nothing ? String(v) : string(p))
 
 # skip a quoted region starting at `i` (opening quote char `q`), where a doubled
 # quote is an escape; returns the index just past the closing quote
@@ -200,7 +203,9 @@ should be descriptive of the migration. The file extension currently must be `.s
 
 Migration files found in `dir` will be checked against a special `$MIGRATIONS_TABLE` table that
 the DBMigrations.jl package manages in the database connection for tracking which migrations have
-already been applied. If a migration file is found in `dir` that has not been applied, it will be
+already been applied. History rows are matched to local files by version; the `installed_rank`
+column records application order (Flyway's semantics for the column, so a history table
+previously managed by Flyway can be picked up). If a migration file is found in `dir` that has not been
 applied to the database. If a migration file is found in `dir` that has already been applied, it
 will be skipped. If a migration file is found in `dir` that has been applied but has changed since
 it was applied, an error will be thrown (migrations should be immutable once applied).
@@ -260,17 +265,23 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
         end
         throw(DuplicateMigrationError([m.script for m in migrations if counts[m.installed_rank] > 1]))
     end
-    # index applied migrations by version; duplicate versions in the db mean the
-    # history table is corrupt and needs manual repair
-    dbbyrank = Dict{Int, Migration}()
+    # index applied migrations by *version*, not installed_rank: Flyway's
+    # installed_rank is an application-order counter, so on a Flyway-written history
+    # it need not equal the version number (rank-based matching silently re-ran
+    # already-applied migrations there). Rows with no version (e.g. Flyway repeatable
+    # migrations) can't correspond to a local versioned file and are ignored.
+    # Duplicate versions in the db mean the history table is corrupt.
+    dbbyversion = Dict{String, Migration}()
     for dbm in dbmigrations
-        haskey(dbbyrank, dbm.installed_rank) && throw(DuplicateMigrationError([m.script for m in dbmigrations if m.installed_rank == dbm.installed_rank]))
-        dbbyrank[dbm.installed_rank] = dbm
+        dbm.version === missing && continue
+        k = versionkey(dbm.version)
+        haskey(dbbyversion, k) && throw(DuplicateMigrationError([x.script for x in dbmigrations if x.version !== missing && versionkey(x.version) == k]))
+        dbbyversion[k] = dbm
     end
     # filter out migrations that have already been applied
     migrations_to_run = Migration[]
     for m in migrations
-        dbm = get(dbbyrank, m.installed_rank, nothing)
+        dbm = get(dbbyversion, versionkey(m.version), nothing)
         if dbm === nothing
             # not applied yet, so it needs to be run
             push!(migrations_to_run, m)
@@ -283,12 +294,20 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     # by default, refuse to apply migrations with versions lower than the highest
     # already-applied version; the old scan-based matching silently *re-ran*
     # already-applied migrations in this situation
-    if !allowoutoforder && !isempty(dbmigrations)
-        maxapplied = maximum(dbm.installed_rank for dbm in dbmigrations)
+    appliedversions = Int[]
+    for dbm in dbmigrations
+        dbm.version === missing && continue
+        p = tryparse(Int, dbm.version)
+        p === nothing || push!(appliedversions, p)
+    end
+    if !allowoutoforder && !isempty(appliedversions)
+        maxapplied = maximum(appliedversions)
         outoforder = [m.script for m in migrations_to_run if m.installed_rank < maxapplied]
         isempty(outoforder) || throw(OutOfOrderMigrationError(outoforder, maxapplied))
     end
-    # run migrations
+    # run migrations; installed_rank records application order (max existing rank + 1
+    # onwards), matching Flyway's semantics for the column
+    nextrank = (isempty(dbmigrations) ? 0 : maximum(dbm.installed_rank for dbm in dbmigrations)) + 1
     for m in migrations_to_run
         DBInterface.transaction(conn) do
             start = time()
@@ -302,9 +321,10 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
                 silent || @info "Applying migration statement:\n$(m.statements)"
                 DBInterface.execute(conn, m.statements)
             end
-            insertmigration!(conn, m, round(Int, (time() - start) * 1000))
+            insertmigration!(conn, m, nextrank, round(Int, (time() - start) * 1000))
             silent || @info "Applied migrations from file: $(m.script)"
         end
+        nextrank += 1
     end
     return migrations_to_run
 end

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -282,6 +282,14 @@ function skipblockcomment(sql, n, i)
     return j
 end
 
+function candollarquote(sql, i)
+    i == firstindex(sql) && return true
+    previous = SubString(sql, prevind(sql, i), prevind(sql, i))
+    # PostgreSQL permits dollar signs in unquoted identifiers. A dollar-quote
+    # delimiter must therefore be separated from a preceding identifier.
+    return !occursin(r"^[\p{L}\p{M}\p{Nd}_\$]$", previous)
+end
+
 """
     DBMigrations.splitsqlstatements(sql::AbstractString)
 
@@ -337,7 +345,7 @@ function splitsqlstatements(sql::AbstractString, mysqlcomments::Bool)
             i = skipblockcomment(sql, n, i)
             executable && (hascontent = true)
             !hascontent && !hint && (stmtstart = i)
-        elseif c == '$' && (m = match(r"^\$[\p{L}\p{M}_][\p{L}\p{M}\p{Nd}_]*\$|^\$\$", SubString(sql, i)); m !== nothing)
+        elseif c == '$' && candollarquote(sql, i) && (m = match(r"^\$[\p{L}\p{M}_][\p{L}\p{M}\p{Nd}_]*\$|^\$\$", SubString(sql, i)); m !== nothing)
             hascontent = true
             closing = findnext(m.match, sql, i + ncodeunits(m.match))
             i = closing === nothing ? n + 1 : nextind(sql, last(closing))

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -92,7 +92,9 @@ end
 Base.showerror(io::IO, e::FailedMigrationError) = print(io, "Migration $(e.script) previously failed (success=false in $MIGRATIONS_TABLE). Manually repair the database and remove the failed row before re-running migrations")
 
 function getmigrations(conn)
-    results = DBInterface.execute(conn, "SELECT * FROM $MIGRATIONS_TABLE")
+    # select columns explicitly: the Migration constructor is positional, so we can't
+    # depend on the physical column order of a pre-existing (e.g. Flyway-created) table
+    results = DBInterface.execute(conn, "SELECT installed_rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success FROM $MIGRATIONS_TABLE ORDER BY installed_rank")
     return [Migration(row...) for row in results]
 end
 

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -78,7 +78,18 @@ end
 
 Base.showerror(io::IO, e::DuplicateMigrationError) = print(io, "Duplicate migration version numbers detected: $(e.migrations)")
 
-prefix(filename) = match(r"^V\d+", basename(filename)).match
+struct OutOfOrderMigrationError <: Exception
+    migrations::Vector{String}
+    maxapplied::Int
+end
+
+Base.showerror(io::IO, e::OutOfOrderMigrationError) = print(io, "Out-of-order migrations detected: $(e.migrations) have versions lower than the highest already-applied migration version ($(e.maxapplied)). Pass `allowoutoforder=true` to apply them anyway")
+
+struct FailedMigrationError <: Exception
+    script::String
+end
+
+Base.showerror(io::IO, e::FailedMigrationError) = print(io, "Migration $(e.script) previously failed (success=false in $MIGRATIONS_TABLE). Manually repair the database and remove the failed row before re-running migrations")
 
 function getmigrations(conn)
     results = DBInterface.execute(conn, "SELECT * FROM $MIGRATIONS_TABLE")
@@ -106,8 +117,22 @@ Migration files may contain multiple SQL statements, separated by semicolons. Ea
 be executed in order. If any statement fails, the entire migration will be rolled back and an error
 will be thrown. If a migration file contains a syntax error, the migration will be rolled back and
 an error will be thrown.
+
+Supported keyword arguments:
+  * `silent::Bool=false`: suppress informational logging while applying migrations
+  * `splitstatements::Bool=true`: split each migration file on semicolons and execute each
+    statement separately; pass `false` to pass each file's contents to the database driver
+    as-is (note some drivers, e.g. SQLite, only execute the first statement of a multi-statement string)
+  * `allowoutoforder::Bool=false`: by default, an `OutOfOrderMigrationError` is thrown if a
+    pending migration has a version lower than the highest already-applied version (e.g. `V2`
+    shows up after `V3` was already applied); pass `true` to apply such migrations anyway
+
+Duplicate migration versions (in the local directory or in the database history table) throw a
+`DuplicateMigrationError`. A migration recorded as failed in the history table (possible when the
+table is shared with other tools like Flyway; this package rolls failed migrations back without
+recording them) throws a `FailedMigrationError` and requires manual repair.
 """
-function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::Bool=true)
+function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::Bool=true, allowoutoforder::Bool=false)
     isdir(dir) || throw(ArgumentError("migrations directory does not exist: `$dir`"))
     # first fetch migrations already applied from the database
     local dbmigrations
@@ -125,26 +150,42 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     end
     files = filter!(x -> match(MIGRATION_FILE_REGEX, basename(x)) !== nothing, readdir(dir; join=true))
     migrations = sort!(map(Migration, files), by=x->x.installed_rank)
+    # check that all local migration versions are unique before comparing against the db
+    if !allunique(m.installed_rank for m in migrations)
+        counts = Dict{Int, Int}()
+        for m in migrations
+            counts[m.installed_rank] = get(counts, m.installed_rank, 0) + 1
+        end
+        throw(DuplicateMigrationError([m.script for m in migrations if counts[m.installed_rank] > 1]))
+    end
+    # index applied migrations by version; duplicate versions in the db mean the
+    # history table is corrupt and needs manual repair
+    dbbyrank = Dict{Int, Migration}()
+    for dbm in dbmigrations
+        haskey(dbbyrank, dbm.installed_rank) && throw(DuplicateMigrationError([m.script for m in dbmigrations if m.installed_rank == dbm.installed_rank]))
+        dbbyrank[dbm.installed_rank] = dbm
+    end
     # filter out migrations that have already been applied
     migrations_to_run = Migration[]
-    db_index = 1
     for m in migrations
-        # find matching db migration
-        while db_index <= length(dbmigrations) && dbmigrations[db_index].installed_rank != m.installed_rank
-            db_index += 1
-        end
-        if db_index > length(dbmigrations)
-            # we checked all applied migrations and didn't find `m`, so it needs to be run
+        dbm = get(dbbyrank, m.installed_rank, nothing)
+        if dbm === nothing
+            # not applied yet, so it needs to be run
             push!(migrations_to_run, m)
-        elseif dbmigrations[db_index].checksum != 0 && dbmigrations[db_index].checksum != m.checksum
-            throw(ChecksumMismatch(m.script, m.checksum, dbmigrations[db_index].checksum))
-        else
-            # we found a matching migration, so we don't need to run it
-            db_index += 1
+        elseif !dbm.success
+            throw(FailedMigrationError(m.script))
+        elseif dbm.checksum != 0 && dbm.checksum != m.checksum
+            throw(ChecksumMismatch(m.script, m.checksum, dbm.checksum))
         end
     end
-    # check that resulting migrations are unique
-    allunique(prefix(m.script) for m in migrations_to_run) || throw(DuplicateMigrationError([m.script for m in migrations_to_run]))
+    # by default, refuse to apply migrations with versions lower than the highest
+    # already-applied version; the old scan-based matching silently *re-ran*
+    # already-applied migrations in this situation
+    if !allowoutoforder && !isempty(dbmigrations)
+        maxapplied = maximum(dbm.installed_rank for dbm in dbmigrations)
+        outoforder = [m.script for m in migrations_to_run if m.installed_rank < maxapplied]
+        isempty(outoforder) || throw(OutOfOrderMigrationError(outoforder, maxapplied))
+    end
     # run migrations
     for m in migrations_to_run
         DBInterface.transaction(conn) do

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -216,6 +216,12 @@ end
 
 Base.showerror(io::IO, e::DuplicateMigrationError) = print(io, "Duplicate migration version numbers detected: $(e.migrations)")
 
+struct DuplicateInstalledRankError <: Exception
+    ranks::Vector{Int}
+end
+
+Base.showerror(io::IO, e::DuplicateInstalledRankError) = print(io, "Duplicate installed_rank values detected in $MIGRATIONS_TABLE: $(e.ranks)")
+
 struct OutOfOrderMigrationError <: Exception
     migrations::Vector{String}
     maxapplied::Union{Int, String}
@@ -486,6 +492,13 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     # must block later migrations even when its version/file is absent locally.
     for dbm in dbmigrations
         dbm.success || throw(FailedMigrationError(dbm.script))
+    end
+    if !allunique(dbm.installed_rank for dbm in dbmigrations)
+        counts = Dict{Int, Int}()
+        for dbm in dbmigrations
+            counts[dbm.installed_rank] = get(counts, dbm.installed_rank, 0) + 1
+        end
+        throw(DuplicateInstalledRankError(sort!([rank for (rank, count) in counts if count > 1])))
     end
     allfiles = filter(isfile, readdir(dir; join=true))
     files = filter(x -> match(MIGRATION_FILE_REGEX, basename(x)) !== nothing, allfiles)

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -55,13 +55,17 @@ const MIGRATION_FILE_REGEX = r"^V(\d+)__(\w+)\.sql$"
 # filename matches MIGRATION_FILE_REGEX
 function Migration(filename::String)
     statements = read(filename, String)
+    # strip a UTF-8 BOM before checksumming/executing, matching Flyway
+    startswith(statements, '\ufeff') && (statements = statements[(1 + ncodeunits('\ufeff')):end])
     m = match(MIGRATION_FILE_REGEX, basename(filename))
     m === nothing && throw(ArgumentError("invalid migration filename: `$(basename(filename))`; must match `V<version>__<description>.sql`"))
     rank = parse(Int, m.captures[1])
     version = string(rank)
     description = String(m.captures[2])
-    lines = split(statements, '\n')
+    # split on \r\n, \r, or \n like Java's BufferedReader.readLine so checksums are
+    # line-ending independent, matching Flyway
     # calculated according to https://github.com/zaunerc/flyway-checksum-tool/blob/master/src/main/java/net/nllk/flywaychecksumtool/LoadableResource.java
+    lines = split(statements, r"\r\n|\r|\n")
     checksum = crc32(lines[1])
     for line in @view lines[2:end]
         checksum = crc32(line, checksum)

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -26,7 +26,7 @@ sqlliteral(s::AbstractString) = string('\'', replace(s, '\'' => "''"), '\'')
 sqlliteral(::Missing) = "NULL"
 
 function insertmigration!(conn, m, etime)
-    DBInterface.execute(conn, "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($(m.installed_rank), $(sqlliteral(m.version)), $(sqlliteral(m.description)), $(sqlliteral(m.type)), $(sqlliteral(m.script)), $(m.checksum), $(sqlliteral(m.installed_by)), $(max(1, etime)), true)")
+    DBInterface.execute(conn, "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($(m.installed_rank), $(sqlliteral(m.version)), $(sqlliteral(m.description)), $(sqlliteral(m.type)), $(sqlliteral(m.script)), $(m.checksum), $(sqlliteral(m.installed_by)), $(max(0, etime)), true)")
 end
 
 struct ChecksumMismatch <: Exception
@@ -213,7 +213,7 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
                 silent || @info "Applying migration statement:\n$(m.statements)"
                 DBInterface.execute(conn, m.statements)
             end
-            insertmigration!(conn, m, round(Int, time() - start))
+            insertmigration!(conn, m, round(Int, (time() - start) * 1000))
             silent || @info "Applied migrations from file: $(m.script)"
         end
     end

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -38,13 +38,21 @@ end
 
 Base.showerror(io::IO, e::ChecksumMismatch) = print(io, "Migration file $(e.filename) has changed since it was applied to the database. Expected checksum $(e.applied_checksum), got $(e.checksum)")
 
+struct DescriptionMismatch <: Exception
+    filename::String
+    description::String
+    applied_description::String
+end
+
+Base.showerror(io::IO, e::DescriptionMismatch) = print(io, "Migration file $(e.filename) has a different description from the migration applied to the database. Expected description $(repr(e.applied_description)), got $(repr(e.description))")
+
 struct Migration
     installed_rank::Int
     version::Union{String, Missing}
     description::String
     type::String
     script::String
-    checksum::Int
+    checksum::Union{Int, Missing}
     installed_by::String
     installed_on::Union{String, DateTime}
     execution_time::Int
@@ -53,7 +61,7 @@ struct Migration
     statements::String
 end
 
-Migration(rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success) = Migration(rank, version, description, type, script, coalesce(checksum, 0), installed_by, installed_on, execution_time, success, "")
+Migration(rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success) = Migration(rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success, "")
 
 const MIGRATION_FILE_REGEX = r"^V(\d+)__(.+)\.sql$"
 
@@ -66,7 +74,8 @@ function Migration(filename::String)
     m === nothing && throw(ArgumentError("invalid migration filename: `$(basename(filename))`; must match `V<version>__<description>.sql`"))
     rank = parse(Int, m.captures[1])
     version = string(rank)
-    description = String(m.captures[2])
+    # Flyway stores descriptions with underscores replaced by spaces.
+    description = replace(String(m.captures[2]), '_' => ' ')
     # split on \r\n, \r, or \n like Java's BufferedReader.readLine so checksums are
     # line-ending independent, matching Flyway
     # calculated according to https://github.com/zaunerc/flyway-checksum-tool/blob/master/src/main/java/net/nllk/flywaychecksumtool/LoadableResource.java
@@ -79,7 +88,7 @@ function Migration(filename::String)
     return Migration(rank, version, description, "SQL", basename(filename), checksum, "DBMigrations.jl", "", 0, false, statements)
 end
 
-==(m1::Migration, m2::Migration) = m1.installed_rank == m2.installed_rank && m1.description == m2.description && m1.script == m2.script && m1.checksum == m2.checksum
+==(m1::Migration, m2::Migration) = m1.installed_rank == m2.installed_rank && m1.description == m2.description && m1.script == m2.script && isequal(m1.checksum, m2.checksum)
 
 struct DuplicateMigrationError <: Exception
     migrations::Vector{String}
@@ -102,6 +111,13 @@ Base.showerror(io::IO, e::FailedMigrationError) = print(io, "Migration $(e.scrip
 
 # normalize integer-like version strings so e.g. '05' and '5' compare equal
 versionkey(v::AbstractString) = (p = tryparse(Int, v); p === nothing ? String(v) : string(p))
+
+# DBMigrations versions before 2.2 stored the raw filename description. Accept that
+# legacy spelling while writing Flyway's space-normalized spelling for new rows.
+function legacydescription(m::Migration)
+    match_ = match(MIGRATION_FILE_REGEX, m.script)
+    return String(match_.captures[2])
+end
 
 # skip a quoted region starting at `i` (opening quote char `q`), where a doubled
 # quote is an escape; returns the index just past the closing quote
@@ -254,6 +270,11 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             rethrow()
         end
     end
+    # Any unresolved failed row means the database may contain partial changes. It
+    # must block later migrations even when its version/file is absent locally.
+    for dbm in dbmigrations
+        dbm.success || throw(FailedMigrationError(dbm.script))
+    end
     allfiles = filter(isfile, readdir(dir; join=true))
     files = filter(x -> match(MIGRATION_FILE_REGEX, basename(x)) !== nothing, allfiles)
     if !silent
@@ -291,9 +312,9 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
         if dbm === nothing
             # not applied yet, so it needs to be run
             push!(migrations_to_run, m)
-        elseif !dbm.success
-            throw(FailedMigrationError(m.script))
-        elseif dbm.checksum != 0 && dbm.checksum != m.checksum
+        elseif dbm.checksum !== missing && dbm.description != m.description && dbm.description != legacydescription(m)
+            throw(DescriptionMismatch(m.script, m.description, dbm.description))
+        elseif dbm.checksum !== missing && dbm.checksum != m.checksum
             throw(ChecksumMismatch(m.script, m.checksum, dbm.checksum))
         end
     end

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -22,13 +22,23 @@ CREATE TABLE $MIGRATIONS_TABLE (
 );
 """
 
-# These packages cannot be hard dependencies, so identify the one driver whose
+# These packages cannot be hard dependencies, so identify the drivers whose
 # DBInterface placeholder and transaction behavior differs from the other supported
 # drivers. LibPQ.DBConnection is the public DBInterface connection wrapper.
 function islibpqconnection(conn)
     T = typeof(conn)
     return nameof(T) === :DBConnection && nameof(parentmodule(T)) === :LibPQ
 end
+
+# Postgres.jl implements the full DBInterface prepared-statement contract (so it
+# takes the generic prepare/execute/close! path), but like LibPQ it speaks native
+# PostgreSQL `$1` placeholders rather than `?`.
+function ispostgresconnection(conn)
+    T = typeof(conn)
+    return nameof(T) === :Connection && nameof(parentmodule(T)) === :Postgres
+end
+
+usesdollarmarkers(conn) = islibpqconnection(conn) || ispostgresconnection(conn)
 
 function ismysqlconnection(conn)
     T = typeof(conn)
@@ -108,7 +118,7 @@ function executebound(conn, sql, params)
 end
 
 function insertmigration!(conn, m, rank, etime)
-    markers = islibpqconnection(conn) ? join(("\$$i" for i = 1:9), ", ") : join(fill("?", 9), ", ")
+    markers = usesdollarmarkers(conn) ? join(("\$$i" for i = 1:9), ", ") : join(fill("?", 9), ", ")
     sql = "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($markers)"
     # MySQL.jl does not bind Bool correctly on all supported releases. Int8(1)
     # round-trips as true through SQLite/MySQL/Postgres/ODBC boolean columns.

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -532,11 +532,9 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             silent || @info "Applying migrations from file: $(m.script)"
             if splitstatements
                 for statement in splitsqlstatements(m.statements, ismysqlconnection(conn))
-                    silent || @info "Applying migration statement:\n$statement"
                     executecommand(conn, statement)
                 end
             else
-                silent || @info "Applying migration statement:\n$(m.statements)"
                 executecommand(conn, m.statements)
             end
             insertmigration!(conn, m, nextrank, round(Int, (time() - start) * 1000))

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -185,6 +185,11 @@ Migration(rank, version, description, type, script, checksum, installed_by, inst
 
 const MIGRATION_FILE_REGEX = r"^V(\d+)__(.+)\.sql$"
 
+function abbreviatedescription(description::String)
+    length(description) <= 200 && return description
+    return first(description, 197) * "..."
+end
+
 # filename matches MIGRATION_FILE_REGEX
 function Migration(filename::String)
     statements = read(filename, String)
@@ -195,7 +200,7 @@ function Migration(filename::String)
     rank = parse(Int, m.captures[1])
     version = string(rank)
     # Flyway stores descriptions with underscores replaced by spaces.
-    description = replace(String(m.captures[2]), '_' => ' ')
+    description = abbreviatedescription(replace(String(m.captures[2]), '_' => ' '))
     # split on \r\n, \r, or \n like Java's BufferedReader.readLine so checksums are
     # line-ending independent, matching Flyway
     # calculated according to https://github.com/zaunerc/flyway-checksum-tool/blob/master/src/main/java/net/nllk/flywaychecksumtool/LoadableResource.java

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -227,6 +227,12 @@ end
 
 Base.showerror(io::IO, e::DuplicateInstalledRankError) = print(io, "Duplicate installed_rank values detected in $MIGRATIONS_TABLE: $(e.ranks)")
 
+struct InvalidDeleteMarkerError <: Exception
+    version::String
+end
+
+Base.showerror(io::IO, e::InvalidDeleteMarkerError) = print(io, "Flyway DELETE marker for version $(e.version) has no active migration row to delete")
+
 struct OutOfOrderMigrationError <: Exception
     migrations::Vector{String}
     maxapplied::Union{Int, String}
@@ -277,6 +283,31 @@ function versiondisplay(parts, original)
         return Int(parts[1])
     end
     return String(original)
+end
+
+function activehistory(dbmigrations)
+    active = trues(length(dbmigrations))
+    for (i, dbm) in enumerate(dbmigrations)
+        uppercase(dbm.type) == "DELETE" || continue
+        active[i] = false
+        dbm.version === missing && continue
+
+        key = versionkey(dbm.version)
+        target = nothing
+        for j = (i - 1):-1:1
+            active[j] || continue
+            candidate = dbmigrations[j]
+            candidate.version === missing && continue
+            versionkey(candidate.version) == key || continue
+            type = uppercase(candidate.type)
+            (type == "BASELINE" || type == "SCHEMA" || type == "DELETE" || startswith(type, "UNDO")) && continue
+            target = j
+            break
+        end
+        target === nothing && throw(InvalidDeleteMarkerError(dbm.version))
+        active[target] = false
+    end
+    return dbmigrations[active]
 end
 
 # DBMigrations versions before 2.2 stored the raw filename description. Accept that
@@ -505,6 +536,7 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
         end
         throw(DuplicateInstalledRankError(sort!([rank for (rank, count) in counts if count > 1])))
     end
+    effectivemigrations = activehistory(dbmigrations)
     allfiles = filter(isfile, readdir(dir; join=true))
     files = filter(x -> match(MIGRATION_FILE_REGEX, basename(x)) !== nothing, allfiles)
     if !silent
@@ -529,16 +561,16 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     # migrations) can't correspond to a local versioned file and are ignored.
     # Duplicate versions in the db mean the history table is corrupt.
     dbbyversion = Dict{String, Migration}()
-    for dbm in dbmigrations
+    for dbm in effectivemigrations
         dbm.version === missing && continue
         k = versionkey(dbm.version)
-        haskey(dbbyversion, k) && throw(DuplicateMigrationError([x.script for x in dbmigrations if x.version !== missing && versionkey(x.version) == k]))
+        haskey(dbbyversion, k) && throw(DuplicateMigrationError([x.script for x in effectivemigrations if x.version !== missing && versionkey(x.version) == k]))
         dbbyversion[k] = dbm
     end
     # A Flyway baseline declares every lower version already represented by the
     # database state even though those versions have no individual history rows.
     baselineversion = nothing
-    for dbm in dbmigrations
+    for dbm in effectivemigrations
         dbm.version === missing && continue
         uppercase(dbm.type) == "BASELINE" || continue
         parts = flywayversionparts(dbm.version)
@@ -571,7 +603,7 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     # already-applied version; the old scan-based matching silently *re-ran*
     # already-applied migrations in this situation
     maxapplied = nothing
-    for dbm in dbmigrations
+    for dbm in effectivemigrations
         dbm.version === missing && continue
         parts = flywayversionparts(dbm.version)
         parts === nothing && continue

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -21,8 +21,12 @@ CREATE TABLE $MIGRATIONS_TABLE (
 );
 """
 
+# render a value as a SQL literal, escaping embedded single quotes
+sqlliteral(s::AbstractString) = string('\'', replace(s, '\'' => "''"), '\'')
+sqlliteral(::Missing) = "NULL"
+
 function insertmigration!(conn, m, etime)
-    DBInterface.execute(conn, "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($(m.installed_rank), '$(m.version)', '$(m.description)', '$(m.type)', '$(m.script)', $(m.checksum), '$(m.installed_by)', $(max(1, etime)), true)")
+    DBInterface.execute(conn, "INSERT INTO $MIGRATIONS_TABLE (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($(m.installed_rank), $(sqlliteral(m.version)), $(sqlliteral(m.description)), $(sqlliteral(m.type)), $(sqlliteral(m.script)), $(m.checksum), $(sqlliteral(m.installed_by)), $(max(1, etime)), true)")
 end
 
 struct ChecksumMismatch <: Exception

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -218,7 +218,7 @@ Base.showerror(io::IO, e::DuplicateMigrationError) = print(io, "Duplicate migrat
 
 struct OutOfOrderMigrationError <: Exception
     migrations::Vector{String}
-    maxapplied::Int
+    maxapplied::Union{Int, String}
 end
 
 Base.showerror(io::IO, e::OutOfOrderMigrationError) = print(io, "Out-of-order migrations detected: $(e.migrations) have versions lower than the highest already-applied migration version ($(e.maxapplied)). Pass `allowoutoforder=true` to apply them anyway")
@@ -229,8 +229,44 @@ end
 
 Base.showerror(io::IO, e::FailedMigrationError) = print(io, "Migration $(e.script) previously failed (success=false in $MIGRATIONS_TABLE). Manually repair the database and remove the failed row before re-running migrations")
 
-# normalize integer-like version strings so e.g. '05' and '5' compare equal
-versionkey(v::AbstractString) = (p = tryparse(Int, v); p === nothing ? String(v) : string(p))
+# Flyway versions contain numeric components separated by dots (underscores are
+# normalized to dots). Trailing zero components do not affect equality.
+function flywayversionparts(v::AbstractString)
+    parts = BigInt[]
+    for part in split(replace(v, '_' => '.'), '.'; keepempty=true)
+        parsed = tryparse(BigInt, part)
+        parsed === nothing && return nothing
+        push!(parts, parsed)
+    end
+    while length(parts) > 1 && last(parts) == 0
+        pop!(parts)
+    end
+    return parts
+end
+
+function compareversions(a::Vector{BigInt}, b::Vector{BigInt})
+    for i = 1:max(length(a), length(b))
+        avalue = i <= length(a) ? a[i] : BigInt(0)
+        bvalue = i <= length(b) ? b[i] : BigInt(0)
+        avalue < bvalue && return -1
+        avalue > bvalue && return 1
+    end
+    return 0
+end
+
+function versionkey(v::AbstractString)
+    parts = flywayversionparts(v)
+    return parts === nothing ? String(v) : join(parts, '.')
+end
+
+localversionparts(m::Migration) = BigInt[BigInt(m.installed_rank)]
+
+function versiondisplay(parts, original)
+    if length(parts) == 1 && typemin(Int) <= parts[1] <= typemax(Int)
+        return Int(parts[1])
+    end
+    return String(original)
+end
 
 # DBMigrations versions before 2.2 stored the raw filename description. Accept that
 # legacy spelling while writing Flyway's space-normalized spelling for new rows.
@@ -481,14 +517,16 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     end
     # A Flyway baseline declares every lower version already represented by the
     # database state even though those versions have no individual history rows.
-    baselineversions = Int[]
+    baselineversion = nothing
     for dbm in dbmigrations
         dbm.version === missing && continue
         uppercase(dbm.type) == "BASELINE" || continue
-        p = tryparse(Int, dbm.version)
-        p === nothing || push!(baselineversions, p)
+        parts = flywayversionparts(dbm.version)
+        parts === nothing && continue
+        if baselineversion === nothing || compareversions(parts, baselineversion[1]) > 0
+            baselineversion = (parts, dbm.version)
+        end
     end
-    baselineversion = isempty(baselineversions) ? nothing : maximum(baselineversions)
     # filter out migrations that have already been applied
     migrations_to_run = Migration[]
     for m in migrations
@@ -496,7 +534,7 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
         if dbm === nothing
             # Versions at or below a Flyway baseline are represented by that baseline
             # row and must not be run against the existing database state.
-            (baselineversion === nothing || m.installed_rank > baselineversion) && push!(migrations_to_run, m)
+            (baselineversion === nothing || compareversions(localversionparts(m), baselineversion[1]) > 0) && push!(migrations_to_run, m)
         elseif uppercase(dbm.type) == "BASELINE"
             # A baseline is synthetic. It represents the database state rather than
             # the local SQL file at the same version, so Flyway does not validate it.
@@ -512,16 +550,18 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     # by default, refuse to apply migrations with versions lower than the highest
     # already-applied version; the old scan-based matching silently *re-ran*
     # already-applied migrations in this situation
-    appliedversions = Int[]
+    maxapplied = nothing
     for dbm in dbmigrations
         dbm.version === missing && continue
-        p = tryparse(Int, dbm.version)
-        p === nothing || push!(appliedversions, p)
+        parts = flywayversionparts(dbm.version)
+        parts === nothing && continue
+        if maxapplied === nothing || compareversions(parts, maxapplied[1]) > 0
+            maxapplied = (parts, dbm.version)
+        end
     end
-    if !allowoutoforder && !isempty(appliedversions)
-        maxapplied = maximum(appliedversions)
-        outoforder = [m.script for m in migrations_to_run if m.installed_rank < maxapplied]
-        isempty(outoforder) || throw(OutOfOrderMigrationError(outoforder, maxapplied))
+    if !allowoutoforder && maxapplied !== nothing
+        outoforder = [m.script for m in migrations_to_run if compareversions(localversionparts(m), maxapplied[1]) < 0]
+        isempty(outoforder) || throw(OutOfOrderMigrationError(outoforder, versiondisplay(maxapplied...)))
     end
     # run migrations; installed_rank records application order (max existing rank + 1
     # onwards), matching Flyway's semantics for the column

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -158,6 +158,14 @@ end
 
 Base.showerror(io::IO, e::DescriptionMismatch) = print(io, "Migration file $(e.filename) has a different description from the migration applied to the database. Expected description $(repr(e.applied_description)), got $(repr(e.description))")
 
+struct TypeMismatch <: Exception
+    filename::String
+    type::String
+    applied_type::String
+end
+
+Base.showerror(io::IO, e::TypeMismatch) = print(io, "Migration file $(e.filename) has a different type from the migration applied to the database. Expected type $(repr(e.applied_type)), got $(repr(e.type))")
+
 struct Migration
     installed_rank::Int
     version::Union{String, Missing}
@@ -489,7 +497,13 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             # Versions at or below a Flyway baseline are represented by that baseline
             # row and must not be run against the existing database state.
             (baselineversion === nothing || m.installed_rank > baselineversion) && push!(migrations_to_run, m)
-        elseif dbm.checksum !== missing && dbm.description != m.description && dbm.description != legacydescription(m)
+        elseif uppercase(dbm.type) == "BASELINE"
+            # A baseline is synthetic. It represents the database state rather than
+            # the local SQL file at the same version, so Flyway does not validate it.
+            continue
+        elseif uppercase(dbm.type) != uppercase(m.type)
+            throw(TypeMismatch(m.script, m.type, dbm.type))
+        elseif dbm.description != m.description && dbm.description != legacydescription(m)
             throw(DescriptionMismatch(m.script, m.description, dbm.description))
         elseif dbm.checksum !== missing && dbm.checksum != m.checksum
             throw(ChecksumMismatch(m.script, m.checksum, dbm.checksum))

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -144,6 +144,10 @@ Split `sql` into individual statements on semicolons, ignoring semicolons that a
 inside single-quoted strings, double-quoted or backtick-quoted identifiers, line (`--`)
 and block (`/* */`, nesting allowed) comments, and Postgres dollar-quoted (`\$tag\$`)
 blocks. Chunks containing only whitespace/comments are dropped.
+
+Quotes are escaped by doubling (`''`), per the SQL standard; non-standard
+backslash-escaped quotes (e.g. MySQL's default `\\'`) are not recognized — use `''` or
+`splitstatements=false` for such files.
 """
 function splitsqlstatements(sql::AbstractString)
     statements = String[]
@@ -185,7 +189,7 @@ function getmigrations(conn)
 end
 
 """
-    DBMigrations.runmigrations(conn::DBInterface.Connection, dir::String)
+    DBMigrations.runmigrations(conn::DBInterface.Connection, dir::String; silent=false, splitstatements=true, allowoutoforder=false)
 
 Using an established database connection `conn` (which should have the appropriate schema already
 selected), search the directory `dir` for migration files and apply them to the database. Migration
@@ -239,12 +243,12 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             rethrow()
         end
     end
-    allfiles = readdir(dir; join=true)
+    allfiles = filter(isfile, readdir(dir; join=true))
     files = filter(x -> match(MIGRATION_FILE_REGEX, basename(x)) !== nothing, allfiles)
     if !silent
         # .sql files that don't match the migration naming pattern are easy to mistake
         # for migrations, so call them out instead of silently ignoring them
-        skipped = [basename(x) for x in allfiles if endswith(x, ".sql") && match(MIGRATION_FILE_REGEX, basename(x)) === nothing]
+        skipped = [basename(x) for x in allfiles if endswith(lowercase(x), ".sql") && match(MIGRATION_FILE_REGEX, basename(x)) === nothing]
         isempty(skipped) || @warn "Ignoring .sql files that don't match the `V<version>__<description>.sql` migration naming pattern: $skipped"
     end
     migrations = sort!(map(Migration, files), by=x->x.installed_rank)

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -30,6 +30,11 @@ function islibpqconnection(conn)
     return nameof(T) === :DBConnection && nameof(parentmodule(T)) === :LibPQ
 end
 
+function ismysqlconnection(conn)
+    T = typeof(conn)
+    return nameof(T) === :Connection && nameof(parentmodule(T)) === :MySQL
+end
+
 function closelibpqresult(conn, sql, params=nothing)
     result = params === nothing ? DBInterface.execute(conn, sql) : DBInterface.execute(conn, sql, params)
     try
@@ -177,20 +182,46 @@ function legacydescription(m::Migration)
     return String(match_.captures[2])
 end
 
-# skip a quoted region starting at `i` (opening quote char `q`), where a doubled
-# quote is an escape; returns the index just past the closing quote
-function skipquoted(sql, n, i, q)
+# skip a quoted region starting at `i`, where a doubled closing character is an
+# escape; returns the index just past the closing character
+function skipquoted(sql, n, i, closing)
     j = nextind(sql, i)
     while j <= n
-        if sql[j] == q
+        if sql[j] == closing
             k = nextind(sql, j)
-            (k <= n && sql[k] == q) || return k
+            (k <= n && sql[k] == closing) || return k
             j = nextind(sql, k)
         else
             j = nextind(sql, j)
         end
     end
     return j
+end
+
+function islinecommentstart(sql, n, i, mysqlcomments)
+    c = sql[i]
+    c == '#' && return mysqlcomments
+    c == '-' || return false
+    second = nextind(sql, i)
+    second <= n && sql[second] == '-' || return false
+    mysqlcomments || return true
+    after = nextind(sql, second)
+    return after > n || isspace(sql[after])
+end
+
+function statementtext(sql, start, stop, lonecommentcrs)
+    relevantcrs = [i for i in lonecommentcrs if start <= i <= stop]
+    isempty(relevantcrs) && return String(strip(SubString(sql, start, stop)))
+
+    io = IOBuffer()
+    position = start
+    for cr in relevantcrs
+        position < cr && write(io, SubString(sql, position, prevind(sql, cr)))
+        write(io, '\n')
+        position = nextind(sql, cr)
+    end
+    position <= stop && write(io, SubString(sql, position, stop))
+    return String(strip(String(take!(io))))
 end
 
 # skip a `/* */` block comment starting at `i`, honoring nesting (Postgres);
@@ -218,39 +249,57 @@ end
     DBMigrations.splitsqlstatements(sql::AbstractString)
 
 Split `sql` into individual statements on semicolons, ignoring semicolons that appear
-inside single-quoted strings, double-quoted or backtick-quoted identifiers, line (`--`)
-and block (`/* */`, nesting allowed) comments, and Postgres dollar-quoted (`\$tag\$`)
-blocks. Chunks containing only whitespace/comments are dropped.
+inside single-quoted strings, double-quoted, backtick-quoted, or bracket-quoted
+identifiers, line (`--`) and block (`/* */`, nesting allowed) comments, and Postgres
+dollar-quoted (`\$tag\$`) blocks. Chunks containing only whitespace/comments are dropped.
 
 Quotes are escaped by doubling (`''`), per the SQL standard; non-standard
 backslash-escaped quotes (e.g. MySQL's default `\\'`) are not recognized — use `''` or
 `splitstatements=false` for such files.
 """
-function splitsqlstatements(sql::AbstractString)
+splitsqlstatements(sql::AbstractString) = splitsqlstatements(sql, false)
+
+function splitsqlstatements(sql::AbstractString, mysqlcomments::Bool)
     statements = String[]
     n = lastindex(sql)
     stmtstart = firstindex(sql)
     hascontent = false
+    lonecommentcrs = Int[]
     i = firstindex(sql)
     while i <= n
         c = sql[i]
         if c == ';'
-            hascontent && push!(statements, strip(SubString(sql, stmtstart, prevind(sql, i))))
+            hascontent && push!(statements, statementtext(sql, stmtstart, prevind(sql, i), lonecommentcrs))
             stmtstart = i = nextind(sql, i)
             hascontent = false
+            empty!(lonecommentcrs)
         elseif c == '\'' || c == '"' || c == '`'
             hascontent = true
             i = skipquoted(sql, n, i, c)
-        elseif c == '-' && (k = nextind(sql, i); k <= n && sql[k] == '-')
+        elseif c == '['
+            hascontent = true
+            i = skipquoted(sql, n, i, ']')
+        elseif islinecommentstart(sql, n, i, mysqlcomments)
             # a lone \r is a line ending too (consistent with the checksum algorithm)
-            i = something(findnext(x -> x == '\n' || x == '\r', sql, k), n + 1)
-            # never emit a statement that *starts* with a comment: some drivers'
-            # tokenizers (e.g. SQLite's, which ends -- comments only at \n) could
-            # see the whole statement as a comment and fail on it
-            hascontent || (stmtstart = i)
+            lineend = something(findnext(x -> x == '\n' || x == '\r', sql, nextind(sql, i)), n + 1)
+            if lineend <= n && sql[lineend] == '\r'
+                after = nextind(sql, lineend)
+                (after > n || sql[after] != '\n') && push!(lonecommentcrs, lineend)
+            end
+            # Preserve line-form optimizer hints, but trim ordinary leading comments.
+            second = c == '-' ? nextind(sql, i) : i
+            after = nextind(sql, second)
+            hint = c == '-' && after <= n && sql[after] == '+'
+            i = lineend
+            !hascontent && !hint && (stmtstart = i)
         elseif c == '/' && (k = nextind(sql, i); k <= n && sql[k] == '*')
+            after = nextind(sql, k)
+            marker = after <= n ? sql[after] : '\0'
+            executable = marker == '!'
+            hint = marker == '+'
             i = skipblockcomment(sql, n, i)
-            hascontent || (stmtstart = i)
+            executable && (hascontent = true)
+            !hascontent && !hint && (stmtstart = i)
         elseif c == '$' && (m = match(r"^\$[\p{L}\p{M}_][\p{L}\p{M}\p{Nd}_]*\$|^\$\$", SubString(sql, i)); m !== nothing)
             hascontent = true
             closing = findnext(m.match, sql, i + ncodeunits(m.match))
@@ -260,7 +309,7 @@ function splitsqlstatements(sql::AbstractString)
             i = nextind(sql, i)
         end
     end
-    hascontent && push!(statements, strip(SubString(sql, stmtstart, n)))
+    hascontent && push!(statements, statementtext(sql, stmtstart, n, lonecommentcrs))
     return statements
 end
 
@@ -398,7 +447,7 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             start = time()
             silent || @info "Applying migrations from file: $(m.script)"
             if splitstatements
-                for statement in splitsqlstatements(m.statements)
+                for statement in splitsqlstatements(m.statements, ismysqlconnection(conn))
                     silent || @info "Applying migration statement:\n$statement"
                     DBInterface.execute(conn, statement)
                 end

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -50,12 +50,16 @@ end
 
 Migration(rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success) = Migration(rank, version, description, type, script, coalesce(checksum, 0), installed_by, installed_on, execution_time, success, "")
 
-# filename matches r"V\d+__\w+\.sql"
+const MIGRATION_FILE_REGEX = r"^V(\d+)__(\w+)\.sql$"
+
+# filename matches MIGRATION_FILE_REGEX
 function Migration(filename::String)
     statements = read(filename, String)
-    rank = parse(Int, match(r"V(\d+)", filename).captures[1])
+    m = match(MIGRATION_FILE_REGEX, basename(filename))
+    m === nothing && throw(ArgumentError("invalid migration filename: `$(basename(filename))`; must match `V<version>__<description>.sql`"))
+    rank = parse(Int, m.captures[1])
     version = string(rank)
-    description = match(r"V\d+__(\w+).sql", filename).captures[1]
+    description = String(m.captures[2])
     lines = split(statements, '\n')
     # calculated according to https://github.com/zaunerc/flyway-checksum-tool/blob/master/src/main/java/net/nllk/flywaychecksumtool/LoadableResource.java
     checksum = crc32(lines[1])
@@ -74,7 +78,7 @@ end
 
 Base.showerror(io::IO, e::DuplicateMigrationError) = print(io, "Duplicate migration version numbers detected: $(e.migrations)")
 
-prefix(filename) = match(r"V\d+", filename).match
+prefix(filename) = match(r"^V\d+", basename(filename)).match
 
 function getmigrations(conn)
     results = DBInterface.execute(conn, "SELECT * FROM $MIGRATIONS_TABLE")
@@ -104,6 +108,7 @@ will be thrown. If a migration file contains a syntax error, the migration will 
 an error will be thrown.
 """
 function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::Bool=true)
+    isdir(dir) || throw(ArgumentError("migrations directory does not exist: `$dir`"))
     # first fetch migrations already applied from the database
     local dbmigrations
     try
@@ -118,7 +123,7 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             rethrow()
         end
     end
-    files = filter!(x -> match(r"V\d+__\w+\.sql", x) !== nothing, readdir(dir; join=true))
+    files = filter!(x -> match(MIGRATION_FILE_REGEX, basename(x)) !== nothing, readdir(dir; join=true))
     migrations = sort!(map(Migration, files), by=x->x.installed_rank)
     # filter out migrations that have already been applied
     migrations_to_run = Migration[]

--- a/src/DBMigrations.jl
+++ b/src/DBMigrations.jl
@@ -35,27 +35,64 @@ function ismysqlconnection(conn)
     return nameof(T) === :Connection && nameof(parentmodule(T)) === :MySQL
 end
 
+function issqliteconnection(conn)
+    T = typeof(conn)
+    return nameof(T) === :DB && nameof(parentmodule(T)) === :SQLite
+end
+
+function closecursor(cursor)
+    if applicable(DBInterface.close!, cursor)
+        DBInterface.close!(cursor)
+    elseif applicable(close, cursor)
+        close(cursor)
+    end
+    return
+end
+
 function closelibpqresult(conn, sql, params=nothing)
     result = params === nothing ? DBInterface.execute(conn, sql) : DBInterface.execute(conn, sql, params)
     try
         return nothing
     finally
-        close(result)
+        closecursor(result)
+    end
+end
+
+function executewithcursor(f, conn, sql, params=nothing)
+    if islibpqconnection(conn)
+        result = params === nothing ? DBInterface.execute(conn, sql) : DBInterface.execute(conn, sql, params)
+        try
+            return f(result)
+        finally
+            closecursor(result)
+        end
+    end
+    actualparams = params === nothing ? () : params
+    return DBInterface.execute(f, conn, sql, actualparams)
+end
+
+function executecommand(conn, sql)
+    if issqliteconnection(conn)
+        # SQLite's direct DBInterface fallback owns a prepared statement that remains
+        # registered until GC. The callback form closes it deterministically.
+        return executewithcursor(_ -> nothing, conn, sql)
+    end
+
+    # Preserve direct execution for arbitrary migration SQL on MySQL, LibPQ, ODBC,
+    # and other drivers. Close the returned cursor when that driver exposes a method.
+    cursor = DBInterface.execute(conn, sql)
+    try
+        return nothing
+    finally
+        closecursor(cursor)
     end
 end
 
 function executebound(conn, sql, params)
-    if islibpqconnection(conn)
-        # LibPQ uses $1 placeholders and its Statement is not a DBInterface.Statement,
-        # so use its direct parameter execution path and close the Result explicitly.
-        closelibpqresult(conn, sql, params)
-    else
-        # SQLite, MySQL, and ODBC use `?`. The callback form closes both the cursor
-        # and the one-shot prepared statement on all three drivers.
-        DBInterface.execute(conn, sql, params) do _
-            nothing
-        end
-    end
+    # LibPQ uses $1 placeholders and its Statement is not a DBInterface.Statement;
+    # executewithcursor uses direct parameter execution there. SQLite, MySQL, and
+    # ODBC use `?` and the callback form closes their one-shot prepared statements.
+    executewithcursor(_ -> nothing, conn, sql, params)
 end
 
 function insertmigration!(conn, m, rank, etime)
@@ -316,8 +353,10 @@ end
 function getmigrations(conn)
     # select columns explicitly: the Migration constructor is positional, so we can't
     # depend on the physical column order of a pre-existing (e.g. Flyway-created) table
-    results = DBInterface.execute(conn, "SELECT installed_rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success FROM $MIGRATIONS_TABLE ORDER BY installed_rank")
-    return [Migration(row...) for row in results]
+    sql = "SELECT installed_rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success FROM $MIGRATIONS_TABLE ORDER BY installed_rank"
+    return executewithcursor(conn, sql) do results
+        [Migration(row...) for row in results]
+    end
 end
 
 """
@@ -370,7 +409,7 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
     catch e
         silent || @warn "Unable to query migrations table, attempting to create:" exception=e
         try
-            DBInterface.execute(conn, MIGRATIONS_TABLE_SCHEMA)
+            executecommand(conn, MIGRATIONS_TABLE_SCHEMA)
             dbmigrations = getmigrations(conn)
         catch e
             @error "Unable to create migrations table" exception=e
@@ -460,11 +499,11 @@ function runmigrations(conn, dir::String; silent::Bool=false, splitstatements::B
             if splitstatements
                 for statement in splitsqlstatements(m.statements, ismysqlconnection(conn))
                     silent || @info "Applying migration statement:\n$statement"
-                    DBInterface.execute(conn, statement)
+                    executecommand(conn, statement)
                 end
             else
                 silent || @info "Applying migration statement:\n$(m.statements)"
-                DBInterface.execute(conn, m.statements)
+                executecommand(conn, m.statements)
             end
             insertmigration!(conn, m, nextrank, round(Int, (time() - start) * 1000))
             silent || @info "Applied migrations from file: $(m.script)"
@@ -476,8 +515,8 @@ end
 
 function clean!(conn::DBInterface.Connection; confirm::Bool=false)
     confirm || throw(ArgumentError("Are you sure you want to delete the record of all previously applied migrations? Database state may be in an inconsistent state for future migrations. Pass `confirm=true` to proceed"))
-    DBInterface.execute(conn, "DROP TABLE $MIGRATIONS_TABLE")
-    DBInterface.execute(conn, MIGRATIONS_TABLE_SCHEMA)
+    executecommand(conn, "DROP TABLE $MIGRATIONS_TABLE")
+    executecommand(conn, MIGRATIONS_TABLE_SCHEMA)
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,6 +347,16 @@ end
         end
     end
 
+    @testset "migration identity equality" begin
+        m1 = DBMigrations.Migration(1, "1", "first", "SQL", "V1__first.sql", 123, "one", "", 0, false, "SELECT 1")
+        same = DBMigrations.Migration(1, "1", "first", "SQL", "V1__first.sql", 123, "two", "2026-01-01", 99, true, "")
+        differenttype = DBMigrations.Migration(1, "1", "first", "JDBC", "V1__first.sql", 123, "one", "", 0, false, "")
+        @test m1 == same
+        @test hash(m1) == hash(same)
+        @test length(Set((m1, same))) == 1
+        @test m1 != differenttype
+    end
+
     @testset "history values with embedded quotes are escaped" begin
         db = SQLite.DB()
         DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,6 +131,31 @@ using SQLite
         end
     end
 
+    @testset "history table with different physical column order" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
+            db = SQLite.DB()
+            # simulate a pre-existing history table whose columns are laid out in a
+            # different physical order than the schema this package creates
+            DBInterface.execute(db, """
+                CREATE TABLE $(DBMigrations.MIGRATIONS_TABLE) (
+                    success BOOLEAN NOT NULL,
+                    version VARCHAR(50),
+                    installed_rank INTEGER NOT NULL,
+                    description VARCHAR(200) NOT NULL,
+                    type VARCHAR(20) NOT NULL,
+                    script VARCHAR(1000) NOT NULL,
+                    checksum INTEGER,
+                    installed_by VARCHAR(100) NOT NULL,
+                    installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    execution_time INTEGER NOT NULL
+                );""")
+            migrations = DBMigrations.runmigrations(db, dir; silent=true)
+            @test length(migrations) == 1
+            @test isempty(DBMigrations.runmigrations(db, dir; silent=true))
+        end
+    end
+
     @testset "Flyway baseline row with NULL checksum" begin
         mktempdir() do dir
             write(joinpath(dir, "V1__baseline.sql"), "CREATE TABLE t1 (x INT);")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,7 +207,11 @@ using SQLite
         # semicolons inside comments
         @test split_("SELECT 1 -- not; a separator\n; SELECT 2") == ["SELECT 1 -- not; a separator", "SELECT 2"]
         @test split_("SELECT 1 /* not; a separator */; SELECT 2") == ["SELECT 1 /* not; a separator */", "SELECT 2"]
-        @test split_("/* nested /* block; */ comment; */ SELECT 1") == ["/* nested /* block; */ comment; */ SELECT 1"]
+        # leading comments are trimmed from emitted statements (SQLite's tokenizer
+        # ends -- comments only at \n, so a statement starting with a comment can be
+        # parsed as all-comment and fail)
+        @test split_("/* nested /* block; */ comment; */ SELECT 1") == ["SELECT 1"]
+        @test split_("-- leading\nSELECT 1; -- inter\nSELECT 2") == ["SELECT 1", "SELECT 2"]
         # Postgres dollar-quoted bodies
         @test split_("CREATE FUNCTION f() RETURNS void AS \$\$ BEGIN PERFORM 1; END; \$\$ LANGUAGE plpgsql; SELECT 1") ==
             ["CREATE FUNCTION f() RETURNS void AS \$\$ BEGIN PERFORM 1; END; \$\$ LANGUAGE plpgsql", "SELECT 1"]
@@ -227,7 +231,7 @@ using SQLite
         # lone \r ends a line comment (CR-only files); statements after the comment
         # used to be silently swallowed into it and never executed
         @test split_("CREATE TABLE t (x INT);\r-- seed\rINSERT INTO t VALUES (1);\r") ==
-            ["CREATE TABLE t (x INT)", "-- seed\rINSERT INTO t VALUES (1)"]
+            ["CREATE TABLE t (x INT)", "INSERT INTO t VALUES (1)"]
     end
 
     @testset "statement splitting during migration" begin
@@ -237,9 +241,13 @@ using SQLite
                 INSERT INTO notes VALUES ('semi;colons; galore');
                 -- trailing comment
                 """)
+            # a CR-only file must fully execute end-to-end (regression: everything
+            # after the first -- comment was silently lost)
+            write(joinpath(dir, "V2__cr_only.sql"), "CREATE TABLE crt (x INT);\r-- seed\rINSERT INTO crt VALUES (1);\r")
             db = SQLite.DB()
-            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 1
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 2
             @test [r.txt for r in DBInterface.execute(db, "SELECT txt FROM notes")] == ["semi;colons; galore"]
+            @test [r.x for r in DBInterface.execute(db, "SELECT x FROM crt")] == [1]
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,6 +156,20 @@ using SQLite
         end
     end
 
+    @testset "checksums are line-ending and BOM independent" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__lf.sql"), "CREATE TABLE t1 (x INT);\nCREATE TABLE t2 (y INT);")
+            write(joinpath(dir, "V2__crlf.sql"), "CREATE TABLE t1 (x INT);\r\nCREATE TABLE t2 (y INT);")
+            write(joinpath(dir, "V3__cr.sql"), "CREATE TABLE t1 (x INT);\rCREATE TABLE t2 (y INT);")
+            write(joinpath(dir, "V4__bom.sql"), "\ufeffCREATE TABLE t1 (x INT);\nCREATE TABLE t2 (y INT);")
+            ms = [DBMigrations.Migration(joinpath(dir, f)) for f in ("V1__lf.sql", "V2__crlf.sql", "V3__cr.sql", "V4__bom.sql")]
+            # reference value computed with Flyway's line-by-line CRC32 algorithm
+            @test all(m.checksum == -1128550967 for m in ms)
+            # BOM must also be stripped from the statements that get executed
+            @test startswith(ms[4].statements, "CREATE")
+        end
+    end
+
     @testset "Flyway baseline row with NULL checksum" begin
         mktempdir() do dir
             write(joinpath(dir, "V1__baseline.sql"), "CREATE TABLE t1 (x INT);")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,48 @@ import DBInterface
 struct Connection <: DBInterface.Connection end
 end
 
+# A minimal stand-in for Postgres.jl. It implements the full DBInterface
+# prepared-statement contract (unlike the LibPQ stub) but, like LibPQ, its server
+# only understands native `$1` placeholders — DBMigrations must select those.
+module Postgres
+import DBInterface
+
+mutable struct Connection <: DBInterface.Connection
+    executions::Vector{Tuple{String, Any}}
+    closed::Int
+    transactions::Vector{String}
+end
+
+struct Statement <: DBInterface.Statement
+    conn::Connection
+    sql::String
+end
+
+struct Result end
+
+DBInterface.prepare(conn::Connection, sql::AbstractString) = Statement(conn, String(sql))
+function DBInterface.execute(statement::Statement, params=())
+    occursin('?', statement.sql) && error("Postgres syntax error at or near \"?\": only \$1-style placeholders are supported")
+    push!(statement.conn.executions, (statement.sql, params))
+    return Result()
+end
+DBInterface.close!(statement::Statement) = (statement.conn.closed += 1)
+DBInterface.close!(::Result) = nothing
+
+# Postgres.jl provides its own DBInterface.transaction override
+function DBInterface.transaction(f, conn::Connection)
+    push!(conn.transactions, "BEGIN")
+    try
+        result = f()
+        push!(conn.transactions, "COMMIT")
+        return result
+    catch
+        push!(conn.transactions, "ROLLBACK")
+        rethrow()
+    end
+end
+end
+
 # ODBC.Cursor intentionally has no DBInterface.close! method in ODBC.jl. This
 # stand-in verifies that DBMigrations closes the owning statement instead.
 module ODBC
@@ -395,6 +437,35 @@ end
         @test params == (7, "1", "backslash\\'quote", "SQL", "V1__backslash\\'quote.sql", 123, "DBMigrations.jl", 9, Int8(1))
         @test !occursin("backslash", sql)
         @test conn.closed == 5
+    end
+
+    @testset "Postgres.jl placeholder and transaction compatibility" begin
+        conn = Postgres.Connection(Tuple{String, Any}[], 0, String[])
+        @test DBMigrations.ispostgresconnection(conn)
+        @test DBMigrations.usesdollarmarkers(conn)
+
+        # regression test (verified live against Postgres 16 via Postgres.jl):
+        # insertmigration! used `?` placeholders here, which PostgreSQL rejects
+        # with `syntax error at or near ","` during server-side prepare
+        m = DBMigrations.Migration(1, "1", "first", "SQL", "V1__first.sql", 123, "DBMigrations.jl", "", 0, false, "")
+        DBMigrations.insertmigration!(conn, m, 4, 9)
+        sql, params = only(conn.executions)
+        @test occursin("VALUES (\$1, \$2, \$3, \$4, \$5, \$6, \$7, \$8, \$9)", sql)
+        @test params == (4, "1", "first", "SQL", "V1__first.sql", 123, "DBMigrations.jl", 9, Int8(1))
+        # the prepared statement is closed deterministically
+        @test conn.closed == 1
+
+        # migrationtransaction routes through Postgres.jl's own DBInterface.transaction
+        result = DBMigrations.migrationtransaction(conn) do
+            42
+        end
+        @test result == 42
+        @test conn.transactions == ["BEGIN", "COMMIT"]
+        empty!(conn.transactions)
+        @test_throws ErrorException DBMigrations.migrationtransaction(conn) do
+            error("migration failed")
+        end
+        @test conn.transactions == ["BEGIN", "ROLLBACK"]
     end
 
     @testset "ODBC cursor compatibility" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,29 @@
 using Test, DBMigrations, DBInterface
 using SQLite
 
+# A minimal stand-in for LibPQ's DBInterface wrapper. LibPQ is intentionally not a
+# test dependency, but its public type/module names select DBMigrations' compatibility
+# path and let the transaction/placeholder behavior be regression-tested.
+module LibPQ
+import DBInterface
+
+mutable struct DBConnection <: DBInterface.Connection
+    executions::Vector{Tuple{String, Any}}
+    closed::Int
+end
+
+struct Result
+    conn::DBConnection
+end
+
+Base.close(result::Result) = (result.conn.closed += 1)
+
+function DBInterface.execute(conn::DBConnection, sql::AbstractString, params=())
+    push!(conn.executions, (String(sql), params))
+    return Result(conn)
+end
+end
+
 @testset "DBMigrations" begin
     @testset "SQLite" begin
         db = SQLite.DB()
@@ -251,6 +274,32 @@ using SQLite
         m2 = DBMigrations.Migration(2, missing, "noversion", "SQL", "V2__noversion.sql", 456, "DBMigrations.jl", "", 0, false, "")
         DBMigrations.insertmigration!(db, m2, 2, 5)
         @test isequal([r.version for r in DBInterface.execute(db, "SELECT version FROM $(DBMigrations.MIGRATIONS_TABLE) WHERE installed_rank = 2")], [missing])
+    end
+
+    @testset "LibPQ parameter and transaction compatibility" begin
+        conn = LibPQ.DBConnection(Tuple{String, Any}[], 0)
+        result = DBMigrations.migrationtransaction(conn) do
+            42
+        end
+        @test result == 42
+        @test first.(conn.executions) == ["BEGIN;", "COMMIT;"]
+        @test conn.closed == 2
+
+        empty!(conn.executions)
+        @test_throws ErrorException DBMigrations.migrationtransaction(conn) do
+            error("migration failed")
+        end
+        @test first.(conn.executions) == ["BEGIN;", "ROLLBACK;"]
+        @test conn.closed == 4
+
+        empty!(conn.executions)
+        m = DBMigrations.Migration(1, "1", "backslash\\'quote", "SQL", "V1__backslash\\'quote.sql", 123, "DBMigrations.jl", "", 0, false, "")
+        DBMigrations.insertmigration!(conn, m, 7, 9)
+        sql, params = only(conn.executions)
+        @test occursin("VALUES (\$1, \$2, \$3, \$4, \$5, \$6, \$7, \$8, \$9)", sql)
+        @test params == (7, "1", "backslash\\'quote", "SQL", "V1__backslash\\'quote.sql", 123, "DBMigrations.jl", 9, Int8(1))
+        @test !occursin("backslash", sql)
+        @test conn.closed == 5
     end
 
     @testset "splitsqlstatements" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,5 +456,21 @@ end
             @test isempty(DBMigrations.runmigrations(db, dir; silent=true))
             @test only(DBMigrations.getmigrations(db)).checksum === missing
         end
+
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE must_not_run_1 (x INT);")
+            write(joinpath(dir, "V4__fourth.sql"), "CREATE TABLE must_not_run_4 (x INT);")
+            write(joinpath(dir, "V6__after_baseline.sql"), "CREATE TABLE after_baseline (x INT);")
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '5', '<< Flyway Baseline >>', 'BASELINE', '<< Flyway Baseline >>', NULL, 'flyway', 0, true)")
+            migrations = DBMigrations.runmigrations(db, dir; silent=true)
+            @test [m.script for m in migrations] == ["V6__after_baseline.sql"]
+            @test_throws SQLiteException DBInterface.execute(db, "SELECT * FROM must_not_run_1")
+            @test_throws SQLiteException DBInterface.execute(db, "SELECT * FROM must_not_run_4")
+            @test isempty(DBInterface.execute(db, "SELECT * FROM after_baseline"))
+            @test [(r.installed_rank, r.version) for r in DBInterface.execute(db, "SELECT installed_rank, version FROM $(DBMigrations.MIGRATIONS_TABLE) ORDER BY installed_rank")] ==
+                [(1, "5"), (2, "6")]
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,13 +184,13 @@ using SQLite
         db = SQLite.DB()
         DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
         m = DBMigrations.Migration(1, "1", "it's got 'quotes'", "SQL", "V1__it's.sql", 123, "DBMigrations.jl", "", 0, false, "")
-        DBMigrations.insertmigration!(db, m, 5)
+        DBMigrations.insertmigration!(db, m, 1, 5)
         stored = only(DBMigrations.getmigrations(db))
         @test stored.description == "it's got 'quotes'"
         @test stored.script == "V1__it's.sql"
         # missing version is stored as NULL, not the string "missing"
         m2 = DBMigrations.Migration(2, missing, "noversion", "SQL", "V2__noversion.sql", 456, "DBMigrations.jl", "", 0, false, "")
-        DBMigrations.insertmigration!(db, m2, 5)
+        DBMigrations.insertmigration!(db, m2, 2, 5)
         @test isequal([r.version for r in DBInterface.execute(db, "SELECT version FROM $(DBMigrations.MIGRATIONS_TABLE) WHERE installed_rank = 2")], [missing])
     end
 
@@ -259,6 +259,46 @@ using SQLite
             @test_throws ArgumentError DBMigrations.clean!(db)
             DBMigrations.clean!(db; confirm=true)
             @test isempty(DBMigrations.getmigrations(db))
+        end
+    end
+
+    @testset "Flyway history where installed_rank != version" begin
+        # Flyway's installed_rank is an application-order counter, so e.g. versions
+        # 1, 2, 5 occupy ranks 1, 2, 3; regression test: rank-based matching treated
+        # version 5 as unapplied and silently re-executed it
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE accounts (balance INT);")
+            write(joinpath(dir, "V2__seed.sql"), "INSERT INTO accounts VALUES (100);")
+            write(joinpath(dir, "V5__bonus.sql"), "UPDATE accounts SET balance = balance + 50;")
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            for (rank, file) in ((1, "V1__first.sql"), (2, "V2__seed.sql"), (3, "V5__bonus.sql"))
+                m = DBMigrations.Migration(joinpath(dir, file))
+                DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($rank, '$(m.version)', '$(m.description)', 'SQL', '$(m.script)', $(m.checksum), 'flyway', 10, true)")
+            end
+            DBInterface.execute(db, "CREATE TABLE accounts (balance INT)")
+            DBInterface.execute(db, "INSERT INTO accounts VALUES (150)")
+            @test isempty(DBMigrations.runmigrations(db, dir; silent=true))
+            @test [r.balance for r in DBInterface.execute(db, "SELECT balance FROM accounts")] == [150]
+            # a new local migration gets the next application rank (4), not its version (6)
+            write(joinpath(dir, "V6__extra.sql"), "CREATE TABLE extra (x INT);")
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 1
+            @test [(r.installed_rank, r.version) for r in DBInterface.execute(db, "SELECT installed_rank, version FROM $(DBMigrations.MIGRATIONS_TABLE) ORDER BY installed_rank")] ==
+                [(1, "1"), (2, "2"), (3, "5"), (4, "6")]
+        end
+    end
+
+    @testset "Flyway repeatable migration row with NULL version" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V2__second.sql"), "CREATE TABLE t2 (x INT);")
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            # a repeatable migration occupies rank 2 with no version; it must not be
+            # confused with local V2 (rank-based matching threw ChecksumMismatch here)
+            DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (2, NULL, 'views', 'SQL', 'R__views.sql', 12345, 'flyway', 10, true)")
+            migrations = DBMigrations.runmigrations(db, dir; silent=true)
+            @test length(migrations) == 1
+            @test migrations[1].script == "V2__second.sql"
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -592,6 +592,35 @@ end
         end
     end
 
+    @testset "Flyway DELETE repair markers" begin
+        mktempdir() do dir
+            path = joinpath(dir, "V1__first.sql")
+            write(path, "SELECT 1;")
+            migration = DBMigrations.Migration(path)
+            db = SQLite.DB()
+            DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            DBMigrations.insertmigration!(db, migration, 1, 0)
+            deleted = DBMigrations.Migration(2, "1", migration.description, "DELETE", migration.script, migration.checksum, "flyway", "", 0, true, "")
+            DBMigrations.insertmigration!(db, deleted, 2, 0)
+
+            # Flyway repair appends a DELETE row instead of removing the original.
+            # The local file is pending again, and the full history still determines
+            # the next installed rank.
+            @test [m.script for m in DBMigrations.runmigrations(db, dir; silent=true)] == ["V1__first.sql"]
+            @test [(row.installed_rank, row.type) for row in DBMigrations.getmigrations(db)] ==
+                [(1, "SQL"), (2, "DELETE"), (3, "SQL")]
+        end
+
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "SELECT 1;")
+            db = SQLite.DB()
+            DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            deleted = DBMigrations.Migration(1, "1", "first", "DELETE", "V1__first.sql", 123, "flyway", "", 0, true, "")
+            DBMigrations.insertmigration!(db, deleted, 1, 0)
+            @test_throws DBMigrations.InvalidDeleteMarkerError DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
     @testset "Flyway repeatable migration row with NULL version" begin
         mktempdir() do dir
             write(joinpath(dir, "V2__second.sql"), "CREATE TABLE t2 (x INT);")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,4 +46,26 @@ using SQLite
         dir = "error2"
         @test_throws DBMigrations.DuplicateMigrationError DBMigrations.runmigrations(db, abspath(joinpath(dirname(pathof(DBMigrations)), "..", "test/sqlite", dir)))
     end
+
+    @testset "directory path containing V<digits>" begin
+        # regression test: rank/prefix used to be parsed from the full path, so a
+        # path segment like `V2` corrupted every migration's version
+        mktempdir() do tmp
+            dir = joinpath(tmp, "appV2", "migrations")
+            mkpath(dir)
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
+            write(joinpath(dir, "V3__third.sql"), "CREATE TABLE t3 (x INT);")
+            db = SQLite.DB()
+            migrations = DBMigrations.runmigrations(db, dir; silent=true)
+            @test length(migrations) == 2
+            @test migrations[1].installed_rank == 1
+            @test migrations[2].installed_rank == 3
+            @test isempty(DBMigrations.runmigrations(db, dir; silent=true))
+        end
+    end
+
+    @testset "nonexistent migrations directory" begin
+        db = SQLite.DB()
+        @test_throws ArgumentError DBMigrations.runmigrations(db, joinpath(@__DIR__, "does_not_exist"))
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -362,6 +362,7 @@ end
         @test split_("SELECT \$\$ unterminated") == ["SELECT \$\$ unterminated"]
         # a lone $ isn't a dollar-quote
         @test split_("SELECT a\$b; SELECT 1") == ["SELECT a\$b", "SELECT 1"]
+        @test split_("SELECT foo\$tag\$bar; SELECT 1") == ["SELECT foo\$tag\$bar", "SELECT 1"]
         # dollar-quote tags may contain non-ASCII identifier characters
         @test split_("SELECT \$é\$ a; b \$é\$; SELECT 1") == ["SELECT \$é\$ a; b \$é\$", "SELECT 1"]
         # lone \r ends a line comment (CR-only files); statements after the comment

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -440,6 +440,7 @@ end
         @test DBMigrations.ismysqlconnection(MySQL.Connection())
         @test mysqlsplit("SELECT 1; # comment; still a comment\nSELECT 2;") == ["SELECT 1", "SELECT 2"]
         @test mysqlsplit("SELECT 2--1; SELECT 3") == ["SELECT 2--1", "SELECT 3"]
+        @test mysqlsplit("/* outer /* inner */ SELECT 1; SELECT 2") == ["SELECT 1", "SELECT 2"]
     end
 
     @testset "statement splitting during migration" begin
@@ -453,11 +454,15 @@ end
             # after the first -- comment was silently lost)
             write(joinpath(dir, "V2__cr_only.sql"), "CREATE TABLE crt (x INT);\r-- seed\rINSERT INTO crt VALUES (1);\r")
             write(joinpath(dir, "V3__inline_cr.sql"), "CREATE TABLE inline_cr (x INT, -- keep y\ry INT);")
+            # SQLite ends a block comment at the first */, even if the comment text
+            # contains another /* opener. PostgreSQL instead supports nesting.
+            write(joinpath(dir, "V4__non_nested_comment.sql"), "/* outer /* inner */ CREATE TABLE after_comment (x INT);")
             db = SQLite.DB()
-            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 3
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 4
             @test [r.txt for r in DBInterface.execute(db, "SELECT txt FROM notes")] == ["semi;colons; galore"]
             @test [r.x for r in DBInterface.execute(db, "SELECT x FROM crt")] == [1]
             @test [r.name for r in DBInterface.execute(db, "PRAGMA table_info(inline_cr)")] == ["x", "y"]
+            @test isempty(DBInterface.execute(db, "SELECT * FROM after_comment"))
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -473,6 +473,17 @@ end
         end
     end
 
+    @testset "migration SQL is not logged" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__secret.sql"), "CREATE TABLE credentials (token TEXT); INSERT INTO credentials VALUES ('top-secret');")
+            db = SQLite.DB()
+            DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            @test_logs (:info, "Applying migrations from file: V1__secret.sql") (:info, "Applied migrations from file: V1__secret.sql") begin
+                DBMigrations.runmigrations(db, dir)
+            end
+        end
+    end
+
     @testset "description charset and non-matching .sql files" begin
         mktempdir() do dir
             # hyphens/dots in descriptions are valid (Flyway allows them)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -237,6 +237,31 @@ using SQLite
         end
     end
 
+    @testset "description charset and non-matching .sql files" begin
+        mktempdir() do dir
+            # hyphens/dots in descriptions are valid (Flyway allows them)
+            write(joinpath(dir, "V1__add-index.v2.sql"), "CREATE TABLE t1 (x INT);")
+            # doesn't match the naming pattern: warned about, not applied
+            write(joinpath(dir, "v2__lowercase.sql"), "CREATE TABLE t2 (x INT);")
+            db = SQLite.DB()
+            migrations = @test_logs (:warn, r"Ignoring \.sql files") match_mode=:any DBMigrations.runmigrations(db, dir)
+            @test length(migrations) == 1
+            @test migrations[1].description == "add-index.v2"
+            @test_throws SQLiteException DBInterface.execute(db, "SELECT * FROM t2")
+        end
+    end
+
+    @testset "clean!" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
+            db = SQLite.DB()
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 1
+            @test_throws ArgumentError DBMigrations.clean!(db)
+            DBMigrations.clean!(db; confirm=true)
+            @test isempty(DBMigrations.getmigrations(db))
+        end
+    end
+
     @testset "Flyway baseline row with NULL checksum" begin
         mktempdir() do dir
             write(joinpath(dir, "V1__baseline.sql"), "CREATE TABLE t1 (x INT);")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -535,6 +535,35 @@ end
         end
     end
 
+    @testset "Flyway numeric version semantics" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "SELECT 1;")
+            write(joinpath(dir, "V2__second.sql"), "SELECT 2;")
+            firstmigration = DBMigrations.Migration(joinpath(dir, "V1__first.sql"))
+            db = SQLite.DB()
+            DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            applied = DBMigrations.Migration(1, "1.0", firstmigration.description, "SQL", firstmigration.script, firstmigration.checksum, "flyway", "", 0, true, "")
+            DBMigrations.insertmigration!(db, applied, 1, 0)
+
+            # Flyway normalizes trailing zero components, so 1.0 is the same
+            # version as local V1. Only V2 is pending.
+            @test [m.script for m in DBMigrations.runmigrations(db, dir; silent=true)] == ["V2__second.sql"]
+        end
+
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "SELECT 1;")
+            write(joinpath(dir, "V2__second.sql"), "SELECT 2;")
+            db = SQLite.DB()
+            DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            applied = DBMigrations.Migration(1, "1.1", "dotted", "SQL", "V1_1__dotted.sql", 123, "flyway", "", 0, true, "")
+            DBMigrations.insertmigration!(db, applied, 1, 0)
+
+            # V1 is older than Flyway version 1.1 and must trigger the same
+            # out-of-order guard as an applied integer version.
+            @test_throws DBMigrations.OutOfOrderMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
     @testset "Flyway repeatable migration row with NULL version" begin
         mktempdir() do dir
             write(joinpath(dir, "V2__second.sql"), "CREATE TABLE t2 (x INT);")
@@ -575,6 +604,18 @@ end
             @test isempty(DBInterface.execute(db, "SELECT * FROM after_baseline"))
             @test [(r.installed_rank, r.version) for r in DBInterface.execute(db, "SELECT installed_rank, version FROM $(DBMigrations.MIGRATIONS_TABLE) ORDER BY installed_rank")] ==
                 [(1, "5"), (2, "6")]
+        end
+
+
+        mktempdir() do dir
+            write(joinpath(dir, "V1__before_dotted_baseline.sql"), "CREATE TABLE must_not_run (x INT);")
+            write(joinpath(dir, "V2__after_dotted_baseline.sql"), "CREATE TABLE after_dotted_baseline (x INT);")
+            db = SQLite.DB()
+            DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            applied = DBMigrations.Migration(1, "1.1", "<< Flyway Baseline >>", "BASELINE", "<< Flyway Baseline >>", missing, "flyway", "", 0, true, "")
+            DBMigrations.insertmigration!(db, applied, 1, 0)
+            @test [m.script for m in DBMigrations.runmigrations(db, dir; silent=true)] == ["V2__after_dotted_baseline.sql"]
+            @test_throws SQLiteException DBInterface.execute(db, "SELECT * FROM must_not_run")
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -514,6 +514,16 @@ end
             @test migrations[1].description == "add-index.v2"
             @test_throws SQLiteException DBInterface.execute(db, "SELECT * FROM t2")
         end
+
+        mktempdir() do dir
+            description = repeat("a", 201)
+            write(joinpath(dir, "V1__$(description).sql"), "SELECT 1;")
+            db = SQLite.DB()
+            migration = only(DBMigrations.runmigrations(db, dir; silent=true))
+            expected = repeat("a", 197) * "..."
+            @test migration.description == expected
+            @test only(DBMigrations.getmigrations(db)).description == expected
+        end
     end
 
     @testset "clean!" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,13 +259,26 @@ end
         mktempdir() do dir
             write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
             db = SQLite.DB()
-            # a table created without the primary key (e.g. by older versions of this
-            # package) can hold duplicate ranks; runmigrations must detect them
+            # A table created without the primary key (e.g. by older versions of this
+            # package) can hold duplicate versions at different application ranks.
             DBInterface.execute(db, replace(DBMigrations.MIGRATIONS_TABLE_SCHEMA, r",\s*CONSTRAINT[^)]*\)" => ""))
-            for script in ("V1__first.sql", "V1__other.sql")
-                DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'first', 'SQL', '$script', 0, 'flyway', 10, true)")
+            for (rank, script) in enumerate(("V1__first.sql", "V1__other.sql"))
+                DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES ($rank, '1', 'first', 'SQL', '$script', 0, 'flyway', 10, true)")
             end
             @test_throws DBMigrations.DuplicateMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
+    @testset "duplicate installed ranks in history table" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V3__third.sql"), "CREATE TABLE must_not_run (x INT);")
+            db = SQLite.DB()
+            DBInterface.execute(db, replace(DBMigrations.MIGRATIONS_TABLE_SCHEMA, r",\s*CONSTRAINT[^)]*\)" => ""))
+            for (version, script) in (("1", "V1__first.sql"), ("2", "V2__second.sql"))
+                DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '$version', 'migration', 'SQL', '$script', 0, 'flyway', 10, true)")
+            end
+            @test_throws DBMigrations.DuplicateInstalledRankError DBMigrations.runmigrations(db, dir; silent=true)
+            @test_throws SQLiteException DBInterface.execute(db, "SELECT * FROM must_not_run")
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,8 +181,50 @@ using SQLite
         # missing version is stored as NULL, not the string "missing"
         m2 = DBMigrations.Migration(2, missing, "noversion", "SQL", "V2__noversion.sql", 456, "DBMigrations.jl", "", 0, false, "")
         DBMigrations.insertmigration!(db, m2, 5)
-        row = only(DBInterface.execute(db, "SELECT version FROM $(DBMigrations.MIGRATIONS_TABLE) WHERE installed_rank = 2"))
-        @test row.version === missing
+        @test isequal([r.version for r in DBInterface.execute(db, "SELECT version FROM $(DBMigrations.MIGRATIONS_TABLE) WHERE installed_rank = 2")], [missing])
+    end
+
+    @testset "splitsqlstatements" begin
+        split_ = DBMigrations.splitsqlstatements
+        @test split_("SELECT 1; SELECT 2") == ["SELECT 1", "SELECT 2"]
+        @test split_("SELECT 1;;SELECT 2;") == ["SELECT 1", "SELECT 2"]
+        # semicolons inside single-quoted strings, incl. '' escapes
+        @test split_("INSERT INTO t VALUES ('a;b'); SELECT 1") == ["INSERT INTO t VALUES ('a;b')", "SELECT 1"]
+        @test split_("INSERT INTO t VALUES ('it''s; fine'); SELECT 1") == ["INSERT INTO t VALUES ('it''s; fine')", "SELECT 1"]
+        # semicolons inside quoted identifiers
+        @test split_("CREATE TABLE \"we;ird\" (x INT); SELECT 1") == ["CREATE TABLE \"we;ird\" (x INT)", "SELECT 1"]
+        @test split_("SELECT `a;b` FROM t; SELECT 1") == ["SELECT `a;b` FROM t", "SELECT 1"]
+        # semicolons inside comments
+        @test split_("SELECT 1 -- not; a separator\n; SELECT 2") == ["SELECT 1 -- not; a separator", "SELECT 2"]
+        @test split_("SELECT 1 /* not; a separator */; SELECT 2") == ["SELECT 1 /* not; a separator */", "SELECT 2"]
+        @test split_("/* nested /* block; */ comment; */ SELECT 1") == ["/* nested /* block; */ comment; */ SELECT 1"]
+        # Postgres dollar-quoted bodies
+        @test split_("CREATE FUNCTION f() RETURNS void AS \$\$ BEGIN PERFORM 1; END; \$\$ LANGUAGE plpgsql; SELECT 1") ==
+            ["CREATE FUNCTION f() RETURNS void AS \$\$ BEGIN PERFORM 1; END; \$\$ LANGUAGE plpgsql", "SELECT 1"]
+        @test split_("SELECT \$tag\$ a; b \$tag\$; SELECT 1") == ["SELECT \$tag\$ a; b \$tag\$", "SELECT 1"]
+        # comment-only/whitespace-only chunks are dropped
+        @test split_("SELECT 1;\n-- done\n") == ["SELECT 1"]
+        @test split_("-- nothing here\n/* at all */") == []
+        @test split_("") == []
+        # unterminated constructs don't hang or throw
+        @test split_("SELECT 'abc") == ["SELECT 'abc"]
+        @test split_("SELECT 1 /* unterminated") == ["SELECT 1 /* unterminated"]
+        @test split_("SELECT \$\$ unterminated") == ["SELECT \$\$ unterminated"]
+        # a lone $ isn't a dollar-quote
+        @test split_("SELECT a\$b; SELECT 1") == ["SELECT a\$b", "SELECT 1"]
+    end
+
+    @testset "statement splitting during migration" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__seed.sql"), """
+                CREATE TABLE notes (txt TEXT);
+                INSERT INTO notes VALUES ('semi;colons; galore');
+                -- trailing comment
+                """)
+            db = SQLite.DB()
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 1
+            @test [r.txt for r in DBInterface.execute(db, "SELECT txt FROM notes")] == ["semi;colons; galore"]
+        end
     end
 
     @testset "Flyway baseline row with NULL checksum" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,31 @@ import DBInterface
 struct Connection <: DBInterface.Connection end
 end
 
+# ODBC.Cursor intentionally has no DBInterface.close! method in ODBC.jl. This
+# stand-in verifies that DBMigrations closes the owning statement instead.
+module ODBC
+import DBInterface
+
+mutable struct Connection <: DBInterface.Connection
+    executions::Vector{Tuple{String, Any}}
+    closed::Int
+end
+
+struct Statement <: DBInterface.Statement
+    conn::Connection
+    sql::String
+end
+
+struct Cursor end
+
+DBInterface.prepare(conn::Connection, sql::AbstractString) = Statement(conn, String(sql))
+function DBInterface.execute(statement::Statement, params=())
+    push!(statement.conn.executions, (statement.sql, params))
+    return Cursor()
+end
+DBInterface.close!(statement::Statement) = (statement.conn.closed += 1)
+end
+
 @testset "DBMigrations" begin
     @testset "SQLite" begin
         db = SQLite.DB()
@@ -323,6 +348,19 @@ end
         @test params == (7, "1", "backslash\\'quote", "SQL", "V1__backslash\\'quote.sql", 123, "DBMigrations.jl", 9, Int8(1))
         @test !occursin("backslash", sql)
         @test conn.closed == 5
+    end
+
+    @testset "ODBC cursor compatibility" begin
+        conn = ODBC.Connection(Tuple{String, Any}[], 0)
+        @test DBMigrations.executewithcursor(_ -> 42, conn, "SELECT 1") == 42
+        @test conn.closed == 1
+
+        m = DBMigrations.Migration(1, "1", "first", "SQL", "V1__first.sql", 123, "DBMigrations.jl", "", 0, false, "")
+        DBMigrations.insertmigration!(conn, m, 1, 5)
+        sql, params = last(conn.executions)
+        @test occursin("VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", sql)
+        @test params == (1, "1", "first", "SQL", "V1__first.sql", 123, "DBMigrations.jl", 5, Int8(1))
+        @test conn.closed == 2
     end
 
     @testset "splitsqlstatements" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,6 +231,30 @@ end
         end
     end
 
+    @testset "Flyway type and NULL checksum validation" begin
+        mktempdir() do dir
+            path = joinpath(dir, "V1__first.sql")
+            write(path, "CREATE TABLE t1 (x INT);")
+            localmigration = DBMigrations.Migration(path)
+
+            # A Flyway Java migration and a local SQL migration are not the same
+            # migration, even when their version, description, and checksum match.
+            db = SQLite.DB()
+            DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            applied = DBMigrations.Migration(1, "1", "first", "JDBC", "V1__first.sql", localmigration.checksum, "flyway", "", 0, true, "")
+            DBMigrations.insertmigration!(db, applied, 1, 0)
+            @test_throws DBMigrations.TypeMismatch DBMigrations.runmigrations(db, dir; silent=true)
+
+            # Flyway treats a NULL applied checksum as matching, but it still checks
+            # the description for ordinary SQL migrations.
+            db = SQLite.DB()
+            DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            applied = DBMigrations.Migration(1, "1", "renamed", "SQL", "V1__first.sql", missing, "flyway", "", 0, true, "")
+            DBMigrations.insertmigration!(db, applied, 1, 0)
+            @test_throws DBMigrations.DescriptionMismatch DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
     @testset "duplicate versions in history table" begin
         mktempdir() do dir
             write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -170,6 +170,21 @@ using SQLite
         end
     end
 
+    @testset "history values with embedded quotes are escaped" begin
+        db = SQLite.DB()
+        DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+        m = DBMigrations.Migration(1, "1", "it's got 'quotes'", "SQL", "V1__it's.sql", 123, "DBMigrations.jl", "", 0, false, "")
+        DBMigrations.insertmigration!(db, m, 5)
+        stored = only(DBMigrations.getmigrations(db))
+        @test stored.description == "it's got 'quotes'"
+        @test stored.script == "V1__it's.sql"
+        # missing version is stored as NULL, not the string "missing"
+        m2 = DBMigrations.Migration(2, missing, "noversion", "SQL", "V2__noversion.sql", 456, "DBMigrations.jl", "", 0, false, "")
+        DBMigrations.insertmigration!(db, m2, 5)
+        row = only(DBInterface.execute(db, "SELECT version FROM $(DBMigrations.MIGRATIONS_TABLE) WHERE installed_rank = 2"))
+        @test row.version === missing
+    end
+
     @testset "Flyway baseline row with NULL checksum" begin
         mktempdir() do dir
             write(joinpath(dir, "V1__baseline.sql"), "CREATE TABLE t1 (x INT);")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,11 @@ function DBInterface.execute(conn::DBConnection, sql::AbstractString, params=())
 end
 end
 
+module MySQL
+import DBInterface
+struct Connection <: DBInterface.Connection end
+end
+
 @testset "DBMigrations" begin
     @testset "SQLite" begin
         db = SQLite.DB()
@@ -312,6 +317,7 @@ end
         # semicolons inside quoted identifiers
         @test split_("CREATE TABLE \"we;ird\" (x INT); SELECT 1") == ["CREATE TABLE \"we;ird\" (x INT)", "SELECT 1"]
         @test split_("SELECT `a;b` FROM t; SELECT 1") == ["SELECT `a;b` FROM t", "SELECT 1"]
+        @test split_("CREATE TABLE [we;ird] (x INT); SELECT 1") == ["CREATE TABLE [we;ird] (x INT)", "SELECT 1"]
         # semicolons inside comments
         @test split_("SELECT 1 -- not; a separator\n; SELECT 2") == ["SELECT 1 -- not; a separator", "SELECT 2"]
         @test split_("SELECT 1 /* not; a separator */; SELECT 2") == ["SELECT 1 /* not; a separator */", "SELECT 2"]
@@ -320,6 +326,10 @@ end
         # parsed as all-comment and fail)
         @test split_("/* nested /* block; */ comment; */ SELECT 1") == ["SELECT 1"]
         @test split_("-- leading\nSELECT 1; -- inter\nSELECT 2") == ["SELECT 1", "SELECT 2"]
+        # Executable MySQL comments and optimizer hints affect semantics and must not
+        # be removed as ordinary leading comments.
+        @test split_("/*!40101 SET @saved = 1 */; SELECT 2") == ["/*!40101 SET @saved = 1 */", "SELECT 2"]
+        @test split_("/*+ INDEX(t idx) */ SELECT * FROM t; SELECT 2") == ["/*+ INDEX(t idx) */ SELECT * FROM t", "SELECT 2"]
         # Postgres dollar-quoted bodies
         @test split_("CREATE FUNCTION f() RETURNS void AS \$\$ BEGIN PERFORM 1; END; \$\$ LANGUAGE plpgsql; SELECT 1") ==
             ["CREATE FUNCTION f() RETURNS void AS \$\$ BEGIN PERFORM 1; END; \$\$ LANGUAGE plpgsql", "SELECT 1"]
@@ -340,6 +350,15 @@ end
         # used to be silently swallowed into it and never executed
         @test split_("CREATE TABLE t (x INT);\r-- seed\rINSERT INTO t VALUES (1);\r") ==
             ["CREATE TABLE t (x INT)", "INSERT INTO t VALUES (1)"]
+        # SQLite does not treat lone CR as a line ending. Only comment terminators
+        # are normalized; CR characters in SQL string literals remain unchanged.
+        @test split_("CREATE TABLE t (x INT, -- keep y\ry INT); SELECT '\r';") ==
+            ["CREATE TABLE t (x INT, -- keep y\ny INT)", "SELECT '\r'"]
+
+        mysqlsplit = sql -> DBMigrations.splitsqlstatements(sql, true)
+        @test DBMigrations.ismysqlconnection(MySQL.Connection())
+        @test mysqlsplit("SELECT 1; # comment; still a comment\nSELECT 2;") == ["SELECT 1", "SELECT 2"]
+        @test mysqlsplit("SELECT 2--1; SELECT 3") == ["SELECT 2--1", "SELECT 3"]
     end
 
     @testset "statement splitting during migration" begin
@@ -352,10 +371,12 @@ end
             # a CR-only file must fully execute end-to-end (regression: everything
             # after the first -- comment was silently lost)
             write(joinpath(dir, "V2__cr_only.sql"), "CREATE TABLE crt (x INT);\r-- seed\rINSERT INTO crt VALUES (1);\r")
+            write(joinpath(dir, "V3__inline_cr.sql"), "CREATE TABLE inline_cr (x INT, -- keep y\ry INT);")
             db = SQLite.DB()
-            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 2
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 3
             @test [r.txt for r in DBInterface.execute(db, "SELECT txt FROM notes")] == ["semi;colons; galore"]
             @test [r.x for r in DBInterface.execute(db, "SELECT x FROM crt")] == [1]
+            @test [r.name for r in DBInterface.execute(db, "PRAGMA table_info(inline_cr)")] == ["x", "y"]
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,6 +222,12 @@ using SQLite
         @test split_("SELECT \$\$ unterminated") == ["SELECT \$\$ unterminated"]
         # a lone $ isn't a dollar-quote
         @test split_("SELECT a\$b; SELECT 1") == ["SELECT a\$b", "SELECT 1"]
+        # dollar-quote tags may contain non-ASCII identifier characters
+        @test split_("SELECT \$é\$ a; b \$é\$; SELECT 1") == ["SELECT \$é\$ a; b \$é\$", "SELECT 1"]
+        # lone \r ends a line comment (CR-only files); statements after the comment
+        # used to be silently swallowed into it and never executed
+        @test split_("CREATE TABLE t (x INT);\r-- seed\rINSERT INTO t VALUES (1);\r") ==
+            ["CREATE TABLE t (x INT)", "-- seed\rINSERT INTO t VALUES (1)"]
     end
 
     @testset "statement splitting during migration" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,12 +123,22 @@ using SQLite
         mktempdir() do dir
             write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
             db = SQLite.DB()
-            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            # a table created without the primary key (e.g. by older versions of this
+            # package) can hold duplicate ranks; runmigrations must detect them
+            DBInterface.execute(db, replace(DBMigrations.MIGRATIONS_TABLE_SCHEMA, r",\s*CONSTRAINT[^)]*\)" => ""))
             for script in ("V1__first.sql", "V1__other.sql")
                 DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'first', 'SQL', '$script', 0, 'flyway', 10, true)")
             end
             @test_throws DBMigrations.DuplicateMigrationError DBMigrations.runmigrations(db, dir; silent=true)
         end
+    end
+
+    @testset "history table primary key rejects duplicate ranks" begin
+        db = SQLite.DB()
+        DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+        insertsql = "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'first', 'SQL', 'V1__first.sql', 0, 'x', 10, true)"
+        DBInterface.execute(db, insertsql)
+        @test_throws SQLiteException DBInterface.execute(db, insertsql)
     end
 
     @testset "history table with different physical column order" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,4 +68,77 @@ using SQLite
         db = SQLite.DB()
         @test_throws ArgumentError DBMigrations.runmigrations(db, joinpath(@__DIR__, "does_not_exist"))
     end
+
+    @testset "out-of-order migrations" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
+            write(joinpath(dir, "V3__third.sql"), "CREATE TABLE t3 (x INT);")
+            db = SQLite.DB()
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 2
+            # V2 shows up after V3 was already applied
+            write(joinpath(dir, "V2__second.sql"), "CREATE TABLE t2 (x INT);")
+            @test_throws DBMigrations.OutOfOrderMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+            # regression test: the old matching logic re-ran already-applied V3 here
+            migrations = DBMigrations.runmigrations(db, dir; silent=true, allowoutoforder=true)
+            @test length(migrations) == 1
+            @test migrations[1].script == "V2__second.sql"
+            @test isempty(DBMigrations.runmigrations(db, dir; silent=true))
+        end
+    end
+
+    @testset "duplicate version of an already-applied migration" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__original.sql"), "CREATE TABLE t1 (x INT);")
+            db = SQLite.DB()
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 1
+            # regression test: a duplicate of an already-applied version used to be
+            # silently run because uniqueness was only checked on pending migrations
+            write(joinpath(dir, "V1__sneaky_duplicate.sql"), "CREATE TABLE t1b (x INT);")
+            @test_throws DBMigrations.DuplicateMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+            @test_throws SQLiteException DBInterface.execute(db, "SELECT * FROM t1b")
+        end
+    end
+
+    @testset "checksum mismatch on modified migration" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
+            db = SQLite.DB()
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 1
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT, y INT);")
+            @test_throws DBMigrations.ChecksumMismatch DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
+    @testset "failed migration recorded in history table" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'first', 'SQL', 'V1__first.sql', 0, 'flyway', 10, false)")
+            @test_throws DBMigrations.FailedMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
+    @testset "duplicate versions in history table" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            for script in ("V1__first.sql", "V1__other.sql")
+                DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'first', 'SQL', '$script', 0, 'flyway', 10, true)")
+            end
+            @test_throws DBMigrations.DuplicateMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
+    @testset "Flyway baseline row with NULL checksum" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__baseline.sql"), "CREATE TABLE t1 (x INT);")
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'baseline', 'BASELINE', 'V1__baseline.sql', NULL, 'flyway', 10, true)")
+            # baseline row means V1 counts as applied even though checksums can't be compared
+            @test isempty(DBMigrations.runmigrations(db, dir; silent=true))
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,18 @@ using SQLite
         end
     end
 
+    @testset "checksum zero is distinct from NULL" begin
+        mktempdir() do dir
+            path = joinpath(dir, "V1__empty.sql")
+            write(path, "")
+            db = SQLite.DB()
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 1
+            @test only(DBMigrations.getmigrations(db)).checksum == 0
+            write(path, "CREATE TABLE changed_after_apply (x INT);")
+            @test_throws DBMigrations.ChecksumMismatch DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
     @testset "failed migration recorded in history table" begin
         mktempdir() do dir
             write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
@@ -116,6 +128,53 @@ using SQLite
             DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
             DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'first', 'SQL', 'V1__first.sql', 0, 'flyway', 10, false)")
             @test_throws DBMigrations.FailedMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+        end
+        # A failed row must also block when no local file has that version. Otherwise
+        # later migrations can run against a database with partial prior changes.
+        mktempdir() do dir
+            write(joinpath(dir, "V2__second.sql"), "CREATE TABLE t2 (x INT);")
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'failed', 'SQL', 'V1__failed.sql', 123, 'flyway', 10, false)")
+            @test_throws DBMigrations.FailedMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+            @test_throws SQLiteException DBInterface.execute(db, "SELECT * FROM t2")
+        end
+        # Failed repeatable rows have no version, but still represent unresolved
+        # partial database changes and must block versioned migrations.
+        mktempdir() do dir
+            write(joinpath(dir, "V1__first.sql"), "CREATE TABLE t1 (x INT);")
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, NULL, 'views', 'SQL', 'R__views.sql', 123, 'flyway', 10, false)")
+            @test_throws DBMigrations.FailedMigrationError DBMigrations.runmigrations(db, dir; silent=true)
+        end
+    end
+
+    @testset "Flyway description normalization and validation" begin
+        mktempdir() do dir
+            path = joinpath(dir, "V1__create_users.sql")
+            write(path, "CREATE TABLE users (id INT);")
+            db = SQLite.DB()
+            DBMigrations.runmigrations(db, dir; silent=true)
+            @test only(DBMigrations.getmigrations(db)).description == "create users"
+
+            # Flyway validates description changes even when the SQL checksum is the
+            # same, so renaming an applied migration must not pass silently.
+            renamed = joinpath(dir, "V1__renamed.sql")
+            mv(path, renamed)
+            @test_throws DBMigrations.DescriptionMismatch DBMigrations.runmigrations(db, dir; silent=true)
+        end
+
+        # Rows written by older DBMigrations releases used raw underscores. Keep
+        # those histories readable while new rows use Flyway's spelling.
+        mktempdir() do dir
+            path = joinpath(dir, "V1__create_users.sql")
+            write(path, "CREATE TABLE users (id INT);")
+            m = DBMigrations.Migration(path)
+            db = SQLite.DB()
+            DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+            DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'create_users', 'SQL', 'V1__create_users.sql', $(m.checksum), 'DBMigrations.jl', 10, true)")
+            @test isempty(DBMigrations.runmigrations(db, dir; silent=true))
         end
     end
 
@@ -322,8 +381,10 @@ using SQLite
             db = SQLite.DB()
             DBInterface.execute(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
             DBInterface.execute(db, "INSERT INTO $(DBMigrations.MIGRATIONS_TABLE) (installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (1, '1', 'baseline', 'BASELINE', 'V1__baseline.sql', NULL, 'flyway', 10, true)")
-            # baseline row means V1 counts as applied even though checksums can't be compared
+            # baseline row means V1 counts as applied even though checksums and
+            # descriptions can't be compared
             @test isempty(DBMigrations.runmigrations(db, dir; silent=true))
+            @test only(DBMigrations.getmigrations(db)).checksum === missing
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,6 +253,24 @@ end
         end
     end
 
+    @testset "one-shot SQLite statements are closed" begin
+        db = SQLite.DB()
+        activehandles() = count(wrapper -> wrapper[] != C_NULL, keys(db.stmt_wrappers))
+        DBMigrations.executecommand(db, DBMigrations.MIGRATIONS_TABLE_SCHEMA)
+        @test activehandles() == 0
+        for _ = 1:100
+            @test isempty(DBMigrations.getmigrations(db))
+        end
+        @test activehandles() == 0
+
+        mktempdir() do dir
+            statements = join(("SELECT $i" for i = 1:100), ";")
+            write(joinpath(dir, "V1__many_statements.sql"), statements)
+            @test length(DBMigrations.runmigrations(db, dir; silent=true)) == 1
+            @test activehandles() == 0
+        end
+    end
+
     @testset "checksums are line-ending and BOM independent" begin
         mktempdir() do dir
             write(joinpath(dir, "V1__lf.sql"), "CREATE TABLE t1 (x INT);\nCREATE TABLE t2 (y INT);")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -399,6 +399,18 @@ end
         end
     end
 
+    @testset "statement splitting escape hatch" begin
+        mktempdir() do dir
+            write(joinpath(dir, "V1__source.sql"), "CREATE TABLE source (value INT);")
+            write(joinpath(dir, "V2__audit.sql"), "CREATE TABLE audit (value INT);")
+            write(joinpath(dir, "V3__trigger.sql"), "CREATE TRIGGER audit_insert AFTER INSERT ON source BEGIN INSERT INTO audit VALUES (NEW.value); END;")
+            db = SQLite.DB()
+            @test length(DBMigrations.runmigrations(db, dir; silent=true, splitstatements=false)) == 3
+            DBInterface.execute(db, "INSERT INTO source VALUES (42)")
+            @test [row.value for row in DBInterface.execute(db, "SELECT value FROM audit")] == [42]
+        end
+    end
+
     @testset "description charset and non-matching .sql files" begin
         mktempdir() do dir
             # hyphens/dots in descriptions are valid (Flyway allows them)


### PR DESCRIPTION
Full-package review (correctness, security, performance, Flyway interop, feature-completeness) implemented as a running list of small logical commits, each with regression tests. Test count: 21 → 84. Two independent review passes (implementation review + fresh-eyes adversarial pass with live repros) came back clean; a codex cross-review follows on this same branch.

## Correctness

- **Re-running already-applied migrations** (`67f1a83`): the two-pointer matching scan never rewound, so with V1,V3 applied, adding V2 re-executed V3 (and inserted its history row twice). Rewritten as keyed lookup; out-of-order pending migrations now throw `OutOfOrderMigrationError` by default with an `allowoutoforder=true` escape hatch (Flyway's `outOfOrder` semantics).
- **Flyway histories where `installed_rank != version`** (`6b10783`): Flyway's `installed_rank` is an application-order counter, not the version. Matching by rank silently re-executed migrations on genuine Flyway tables (verified: versions 1,2,5 at ranks 1,2,3 → V5's `UPDATE` ran twice with no error) and a repeatable-migration row (NULL version) could permanently block a versioned migration with a spurious `ChecksumMismatch`. History rows are now matched by **version** (identical behavior for histories this package wrote, where rank == version), NULL-version rows are ignored, and inserted rows record `installed_rank` as max(rank)+1 like Flyway. *Note: this deliberately supersedes part of e289cbf ("use installed rank to compare") — rank comparison was only sound when rank == version.*
- **Duplicate versions** (`67f1a83`): uniqueness was only checked on *pending* migrations, so a duplicate of an already-applied version was silently executed. Now checked across all local files and all history rows; history rows recorded as failed (`success=false`, possible when sharing the table with Flyway) throw `FailedMigrationError` instead of being treated as applied.
- **Path-dependent filename parsing** (`3bb8798`): rank/description/prefix regexes ran unanchored against the full path, so a directory like `/app/V2/migrations/` corrupted every parsed version and made duplicate detection compare `"V2"` to `"V2"` for all files. All parsing now anchored against `basename`; nonexistent directory errors early.
- **Checksums not line-ending independent** (`bb40def`): checksums split only on `\n`, so CRLF checkouts (Windows autocrlf) produced cross-platform `ChecksumMismatch`es and diverged from Flyway. Now splits on `\r\n|\r|\n` and strips a UTF-8 BOM, matching Flyway's `BufferedReader.readLine`-based CRC32; locked with a reference value verified independently (Python zlib). **Behavioral note:** files with CRLF endings previously applied will report a checksum mismatch once (the old stored checksum included `\r`); LF files are unaffected.
- **Naive semicolon splitting** (`882b7a0`, `c1081db`, `76414c2`): statements were split on every `;`, breaking semicolons inside string literals, quoted identifiers, comments, and Postgres dollar-quoted function bodies — and in CR-only files, everything after the first `--` comment was silently swallowed (recorded as applied, never executed). Added `splitsqlstatements`, a lexical scanner handling `''` escapes, double-quote/backtick identifiers, `--` and nested `/* */` comments, and `$tag$` blocks (unicode tags included); comment-only chunks are dropped and emitted statements never begin with a comment (SQLite's tokenizer only ends `--` comments at `\n`).
- **`SELECT *` column-order dependence** (`9b4376c`): history rows were splatted positionally into the `Migration` constructor from `SELECT *`, mis-assigning every field on a table with different physical column order. Columns are now selected explicitly, with `ORDER BY installed_rank`.

## Security / robustness

- **SQL string interpolation** (`960825f`): history values were interpolated raw into the INSERT; any embedded `'` produced malformed SQL (an injection vector in the general case) and a `missing` version was stored as the literal string `"missing"`. Values are now quote-escaped (`''` doubling, portable across SQLite/MySQL/Postgres) and missing → NULL.
- **Schema primary key** (`09c57b0`): the history table had no constraints; new installs now get Flyway's `PRIMARY KEY (installed_rank)`.
- **Silently ignored migration files** (`7404910`): descriptions were restricted to `\w+`, so valid Flyway names like `V10__add-index.sql` were *silently skipped* — the schema change just never happened. The full Flyway description charset is now accepted, and remaining non-matching `.sql` files produce a warning listing them.

## Flyway interop details

- `execution_time` now recorded in milliseconds (was rounded seconds) (`469ffdf`).
- NULL-checksum baseline rows continue to mark their version as applied (pre-existing behavior, now regression-tested).

## CI / docs

- GitHub Actions were node12-era (`checkout@v2`, `cache@v1`, `codecov@v1`) and fail on current runners; updated throughout, nightly marked `continue-on-error`, Julia 1.6 excluded on ARM macOS (no pre-1.8 Apple Silicon binaries), and a docs job added (`51fdc42`, `1e141a6`).
- README documented a nonexistent `__migrations__` table; docs/ still built Example.jl and deployed to quinnj/Example.jl. Both rewritten to match actual behavior, including kwargs, error types, and a Limitations section (no locking; MySQL DDL auto-commit; versioned-only; `''`-escaping only) (`ff7b8b7`).

## Known limitations (documented, not addressed)

- No cross-process locking during `runmigrations` (Flyway locks the history table); coordinate deployments externally.
- Rollback of failed migrations relies on transactional DDL (SQLite/Postgres yes; MySQL auto-commits DDL).
- No repeatable (`R__`) or undo migrations; existing Flyway `R__` rows are tolerated but the files are not executed.
- Statement splitter recognizes standard `''` escaping only (not MySQL's default `\'`); `splitstatements=false` is the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
